### PR TITLE
make sure switching between php5 and php7 works

### DIFF
--- a/provisioning/roles/php/tasks/php5.yml
+++ b/provisioning/roles/php/tasks/php5.yml
@@ -6,6 +6,7 @@
   apt: pkg={{ item }} state=latest
   sudo: yes
   with_items:
+    - php5-common
     - php5-xdebug
     - php5-curl
     - php5-cli

--- a/provisioning/roles/php/tasks/php7.yml
+++ b/provisioning/roles/php/tasks/php7.yml
@@ -10,6 +10,7 @@
   with_items:
 # xdebug is not available for now in dotdeb :/
 #    - php7.0-xdebug
+    - php7.0-common
     - php7.0-curl
     - php7.0-cli
     - php7.0-intl


### PR DESCRIPTION
When you change php_version in paramters.yml and just do a new vagrant provision instead of destroy/up, it should work now