### PR TITLE
Dont use ternary

### DIFF
--- a/provisioning/roles/django/tasks/main.yml
+++ b/provisioning/roles/django/tasks/main.yml
@@ -15,7 +15,7 @@
   when: database_type is defined
 
 - name: create venv with latest pip version
-  pip: "virtualenv={{ env_root }} name=pip state=latest virtualenv_command={{ (python_version|int == 2) | ternary('virtualenv', 'pyvenv') }}"
+  pip: "virtualenv={{ env_root }} name=pip state=latest virtualenv_command={{ 'virtualenv' if (python_version|int == 2) else 'pyvenv') }}"
 
 - name: install base packages in venv
   pip: "requirements={{ django_root }}/{{ django_pip_requirements }} virtualenv={{ env_root }}"

--- a/provisioning/roles/flask/tasks/main.yml
+++ b/provisioning/roles/flask/tasks/main.yml
@@ -3,7 +3,7 @@
   file: path=/vagrant/envdir state=directory
 
 - name: create venv and install base packages
-  pip: "requirements={{ root_directory }}/{{ flask_pip_requirements }} virtualenv={{ env_root }} virtualenv_command={{ (python_version|int == 2) | ternary('virtualenv', 'pyvenv') }}"
+  pip: "requirements={{ root_directory }}/{{ flask_pip_requirements }} virtualenv={{ env_root }} virtualenv_command={{ 'virtualenv' if (python_version|int == 2) else 'pyvenv' }}"
 
 - name: activate virtualenv when sshing into the box
   lineinfile: dest=~/.bashrc line='. {{ env_root }}/bin/activate'

--- a/provisioning/roles/nginx/defaults/main.yml
+++ b/provisioning/roles/nginx/defaults/main.yml
@@ -18,5 +18,5 @@ static_dir: false
 static_fs_dir: ""
 expire_time: 6h # expire time of static files
 
-fpm_socket: "{{ (php_version_installed == 7.0) | ternary('/run/php/php7.0-fpm.sock', '/var/run/php5-fpm.sock') }}"
+fpm_socket: "{{ '/run/php/php7.0-fpm.sock' if (php_version_installed|float == 7.0) else '/var/run/php5-fpm.sock' }}"
 

--- a/provisioning/roles/php-apache/tasks/main.yml
+++ b/provisioning/roles/php-apache/tasks/main.yml
@@ -1,6 +1,6 @@
 - include: php7.yml
-  when: "{{ php_version_installed }} == 7.0"
+  when: "{{ php_version_installed|float }} == 7.0"
 
 - include: php5.yml
-  when: "{{ php_version_installed }} < 7.0"
+  when: "{{ php_version_installed|float }} < 7.0"
 

--- a/provisioning/roles/php-fpm/handlers/main.yml
+++ b/provisioning/roles/php-fpm/handlers/main.yml
@@ -1,4 +1,4 @@
 - name: restart php-fpm
   service:
-    name: "{{ (php_version | float == 7.0) | ternary('php7.0-fpm', 'php5-fpm') }}"
+    name: "{{ 'php7.0-fpm' if (php_version_installed|float == 7.0) else 'php5-fpm' }}"
     state: restarted

--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -1,6 +1,6 @@
 - set_fact: phpfpm_installed=true
 
 - name: install php-fpm
-  apt: pkg={{ (php_version_installed == 7.0) | ternary('php7.0-fpm', 'php5-fpm') }} state=latest
+  apt: pkg={{ 'php7.0-fpm' if (php_version_installed|float == 7.0)  else 'php5-fpm' }} state=latest
   sudo: yes
 

--- a/provisioning/roles/python/tasks/main.yml
+++ b/provisioning/roles/python/tasks/main.yml
@@ -33,5 +33,5 @@
     - libtiff5-dev
 
 - name: install libjpeg-dev
-  apt: pkg="{{ (ansible_lsb.major_release|int == 7) | ternary('libjpeg8-dev', 'libjpeg-dev') }}" state=latest
+  apt: pkg="{{ 'libjpeg8-dev' if (ansible_lsb.major_release|int == 7) else 'libjpeg-dev' }}" state=latest
   sudo: yes

--- a/provisioning/roles/solr/defaults/main.yml
+++ b/provisioning/roles/solr/defaults/main.yml
@@ -1,8 +1,8 @@
 solr_base_dir: "/opt/solr"
 solr_version: "5.3.1"
 
-solr_base_url_filename: "{{ solr_version | version_compare('4.1.0', '<') | ternary('apache-', '') }}"
-solr_base_config_dir: "{{ solr_version | version_compare('5.0.0', '<') | ternary('example', 'server') }}"
+solr_base_url_filename: "{{ 'apache-' if (solr_version | version_compare('4.1.0', '<')) else '' }}"
+solr_base_config_dir: "{{ 'example' if  (solr_version | version_compare('5.0.0', '<')) else 'server' }}"
 
 solr_url: "http://archive.apache.org/dist/lucene/solr/{{ solr_version }}/{{ solr_base_url_filename }}solr-{{ solr_version }}.tgz"
 
@@ -11,7 +11,6 @@ solr_install_dir: "{{ solr_base_dir }}"
 solr_config_dir: "{{ solr_base_dir }}/{{ solr_base_config_dir }}/solr"
 
 solr_port: "8984"
-solr_command: "{{ solr_version | version_compare('4.10.0', '<') | ternary(
-  'java -jar ' + solr_install_dir + '/example/start.jar -Djetty.home=' + solr_install_dir + '/example -Dsolr.solr.home=' + solr_config_dir + ' -Djetty.port=' + solr_port,
-  solr_install_dir + '/bin/solr start -f -p ' + solr_port + ' -s ' + solr_config_dir
-) }}"
+solr_command: "{{ 'java -jar ' + solr_install_dir + '/example/start.jar -Djetty.home=' + solr_install_dir + '/example -Dsolr.solr.home=' + solr_config_dir + ' -Djetty.port=' + solr_port 
+if    solr_version | version_compare('4.10.0', '<') 
+else  solr_install_dir + '/bin/solr start -f -p ' + solr_port + ' -s ' + solr_config_dir }}"


### PR DESCRIPTION
ternary is not available in ansible 1.7, which is used (at least on jessie) when the ansible_local provisioner is used.

Replace them with `'foo' if bar else 'baz'`

also cast php_version_installed to float where needed, this makes #53 unnecessary  (it was used in just one line which was not a ternary anyway)