### PR TITLE
Fixed errors with php paths

### DIFF
--- a/provisioning/roles/php/tasks/not-debian-7.0.yml
+++ b/provisioning/roles/php/tasks/not-debian-7.0.yml
@@ -2,7 +2,7 @@
   template: src={{ item.src }} dest={{ item.dest }} owner=root group=root mode=644
   sudo: yes
   with_items:
-    - { src: php.ini.j2, dest: "{{ etc_php_path }}/mods-available/php-dev.ini" }
+    - { src: php.ini.j2, dest: "{{ etc_php_path }}{{ php_version_installed }}/mods-available/php-dev.ini" }
 
 - name: Activate PHP configuration files
   command: "{{phpenmod}} {{ item }}"


### PR DESCRIPTION
The variable `{{ etc_php_path }}` is set to `/etc/php/` , but `mods-available` are depending to the PHP version that is currently installed/used.
I added `{{ php_version_installed }}/` to correctly fix it.