### PR TITLE
when the test script is not found, this should lead to a failed build

### DIFF
--- a/ci/start.sh
+++ b/ci/start.sh
@@ -43,15 +43,16 @@ then
       vagrant ssh -c "echo $THISPROVISION > /home/vagrant/provisionbuild.last" $VIRTUALBOX_NAME
     fi
 else
-    vagrant up $VIRTUALBOX_NAME --provider lxc --provision 
+    vagrant up $VIRTUALBOX_NAME --provider lxc --provision
 fi
 
-if [ -f $CI_TEST_SCRIPT ]; 
+if [ -f $CI_TEST_SCRIPT ];
 then
     echo -e "- Run $CI_TEST_SCRIPT"
-    vagrant ssh $VIRTUALBOX_NAME -- -t "cd /vagrant && $CI_TEST_SCRIPT" 
+    vagrant ssh $VIRTUALBOX_NAME -- -t "cd /vagrant && $CI_TEST_SCRIPT"
 else
     echo -e "\033[31mNo test script found ($CI_TEST_SCRIPT) \e[0m"
+    exit 1
 fi
 
 trap - EXIT SIGHUP SIGINT SIGTERM


### PR DESCRIPTION
gitlabci considers a build green if the test script was not found, thus hiding a mistakes. exiting with a non-0 status at this point should make it notice that there is a problem.