### PR TITLE
set php alternative path for easy switching between php versions

### DIFF
--- a/provisioning/roles/php/tasks/main.yml
+++ b/provisioning/roles/php/tasks/main.yml
@@ -46,6 +46,10 @@
 - include: wheezy-php5.yml
   when: "ansible_lsb.major_release|int < 8 and {{ php_version_installed }} > 5.4"
 
+- name: set php alternative to the correct path 
+  alternatives: name=php path={{ alternatives_php_path }}
+  sudo: yes
+  
 - name: Download php-cs-fixer
   shell: curl http://get.sensiolabs.org/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer && chmod +x /usr/local/bin/php-cs-fixer creates=/usr/local/bin/php-cs-fixer
   sudo: yes

--- a/provisioning/roles/php/tasks/ubuntu-php5.yml
+++ b/provisioning/roles/php/tasks/ubuntu-php5.yml
@@ -1,5 +1,0 @@
-- name: ubuntu-php5 | ppa:ondrej/php5-5.6
-  apt_repository: repo='ppa:ondrej/php5-5.6'
-  sudo: yes
-  when: "{{ php_version_installed }} == 5.6"
-

--- a/provisioning/roles/php/vars/Debian-7.0.yml
+++ b/provisioning/roles/php/vars/Debian-7.0.yml
@@ -17,3 +17,4 @@ php_pgsql_package: php7.0-pgsql
 
 etc_php_path: /etc/php/7.0/
 
+alternatives_php_path: /usr/bin/php7.0

--- a/provisioning/roles/php/vars/Debian.yml
+++ b/provisioning/roles/php/vars/Debian.yml
@@ -15,3 +15,5 @@ php_pgsql_package: php5-pgsql
 etc_php_path: /etc/php5/
 
 phpenmod: php5enmod
+
+alternatives_php_path: /usr/bin/php5

--- a/provisioning/roles/php/vars/Ubuntu-5.6.yml
+++ b/provisioning/roles/php/vars/Ubuntu-5.6.yml
@@ -23,3 +23,5 @@ php_pgsql_package: php5.6-pgsql
 etc_php_path: /etc/php/5.6/
 
 phpenmod: phpenmod
+
+alternatives_php_path: /usr/bin/php5.6

--- a/provisioning/roles/php/vars/Ubuntu-7.0.yml
+++ b/provisioning/roles/php/vars/Ubuntu-7.0.yml
@@ -25,3 +25,5 @@ etc_php_path: /etc/php/7.0/
 
 #php5enmod auf debian
 phpenmod: phpenmod
+
+alternatives_php_path: /usr/bin/php7.0

--- a/provisioning/roles/php/vars/default.yml
+++ b/provisioning/roles/php/vars/default.yml
@@ -16,4 +16,4 @@ etc_php_path: /etc/php5/
 
 phpenmod: php5enmod
 
-
+alternatives_php_path: /usr/bin/php5


### PR DESCRIPTION
Needed, since it's now possible to install different php versions at once. And when we want to switch from one to another via provisioning, we need to update the alternatives
