### PR TITLE
if ansible is not installed, try version 1.9.4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,6 +122,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             # changes sshd configuration. If controlmaster is used, the new sshd
             # configuration is not taken into account
             ansible.raw_ssh_args = ['-o ControlMaster=no']
+        else 
+            ansible.install = true
+            ansible.version = "1.9.4"
+            ansible.install_mode = :pip
         end
     end
 


### PR DESCRIPTION
ansible.install is true by default. so in case it's not installed (it should in all drifter base boxes), try to use 1.9.4 (or ansible provisioning will most certainly fail)

