### PR TITLE
Move gettext installation from Django to virtualenv

### DIFF
--- a/provisioning/roles/django/tasks/main.yml
+++ b/provisioning/roles/django/tasks/main.yml
@@ -4,11 +4,6 @@
 # This role requires either the postgresql or mysql roles to be enabled
 # Please note that Python 3 compatibility is only supported since jessie
 
-# Gettext is used by Django's compilemessages
-- name: ensure gettext is installed
-  apt: pkg=gettext state=latest
-  become: yes
-
 - name: fill in DATABASE_URL setting
   copy: "dest={{ django_root }}/envdir/DATABASE_URL content={{ database_type }}://{{ database_user }}:{{ database_user }}@localhost/{{ database_name }}"
   when: database_type is defined

--- a/provisioning/roles/virtualenv/tasks/main.yml
+++ b/provisioning/roles/virtualenv/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+# Gettext is used by some python base packages
+- name: ensure gettext is installed
+  apt: pkg=gettext state=latest
+  become: yes
+
 - name: create the local environement directory
   file: path=/vagrant/envdir state=directory
 


### PR DESCRIPTION
Provisioning of a Django project with something needing to compile messages in requirements/dev.txt will fail at the "create venv and install base packages" task.

gettext needs to be available before that step, and there was no way to specify this ordering in the project-specific playbook.
