### PR TITLE
Revert python 3.4-specific installation, supposedly for Ubuntu

### DIFF
--- a/provisioning/roles/python/tasks/main.yml
+++ b/provisioning/roles/python/tasks/main.yml
@@ -19,7 +19,7 @@
   with_items:
     - python3-pip
     - python3-all-dev
-    - python3.4-venv
+    - python3-venv
   when: ansible_lsb.major_release|int >= 8
 
 - name: install pillow dependencies


### PR DESCRIPTION
The commit that introduced the installation of python3.4-venv instead of python3-venv was justified by "Ubuntu doesn't have python3-venv". This doesn't make sense given the `ansible_lsb.major_release|int >= 8` below.

(Arguably, all Ubuntu releases fill this criteria, but it's obviously there for Debian-specific purposes).

Furthermore, python3.4-venv doesn't provide "pyvenv" that is used in https://github.com/liip/drifter/blob/master/provisioning/roles/virtualenv/tasks/main.yml#L6 .

The revert is the easy fix, that fixes the problem on the Debian images we use; it could be possible to add more workarounds though :)