### PR TITLE
Ensure that git is installed before syncing git config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - fix the default nginx vhost when setting up an index file
 - flush handlers at the end of relevent roles to ensure services are available
 - fix an error where the destination directory contains spaces
+- ensure git is installed before synching git config
 
 ## [1.0.6] - 2016-08-12
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,6 +111,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                                           echo export GITLAB_CI=#{ENV['GITLAB_CI']} >> /etc/profile.d/drifter_vars.sh;
                                           chmod a+x /etc/profile.d/drifter_vars.sh"
 
+    # Ensure that git is installed in the vagrant box.
+    config.vm.provision "shell", inline: "git --version >/dev/null 2>&1 || sudo apt-get -y install git"
+
     # Sync the git configuration over
     sync_git = <<SCRIPT
 echo -e "#{git_config}" > /tmp/gitconfig-host


### PR DESCRIPTION

* This PR is a : Bugfix

This allows the initial provisioning to work on vagrant base boxes that don't already have git installed.

