### PR TITLE
WIP: Remove deprecated "always_populate_raw_post_data"

### DIFF
--- a/provisioning/roles/php/templates/php.ini.j2
+++ b/provisioning/roles/php/templates/php.ini.j2
@@ -15,3 +15,5 @@ default_charset = "{{ php_default_charset }}"
 default_socket_timeout = "{{ php_default_socket_timeout }}"
 
 short_open_tag = Off
+
+always_populate_raw_post_data = -1


### PR DESCRIPTION
Latest PHP (including 5.6) releases will complain if `always_populate_raw_post_data` is enabled,  by outputting a warning message like:

`<b>Deprecated</b>:  Automatically populating $HTTP_RAW_POST_DATA is deprecated and will be removed in a future version. To avoid this warning set 'always_populate_raw_post_data' to '-1' in php.ini and use the php://input stream instead. in <b>Unknown</b> on line <b>0</b><br />`
