### PR TITLE
Duplicate index argument in PHP templates for Nginx

### DIFF
--- a/provisioning/roles/nginx/templates/php-site.j2
+++ b/provisioning/roles/nginx/templates/php-site.j2
@@ -1,8 +1,6 @@
 {% extends "default-site.j2" %}
 
-{% block index %}
-    index index.php;
-{% endblock %}
+{% block index %}index.php{% endblock %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/silex-site.j2
+++ b/provisioning/roles/nginx/templates/silex-site.j2
@@ -1,8 +1,6 @@
 {% extends "default-site.j2" %}
 
-{% block index %}
-    index index.php;
-{% endblock %}
+{% block index %}index.php{% endblock %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/symfony2-site.j2
+++ b/provisioning/roles/nginx/templates/symfony2-site.j2
@@ -1,8 +1,6 @@
 {% extends "default-site.j2" %}
 
-{% block index %}
-    index index.php;
-{% endblock %}
+{% block index %}index.php{% endblock %}
 
 {% block extra %}
     {{ super() }}


### PR DESCRIPTION
The various PHP templates that overrides the `index` block add too much information since the prefix `index` and the end-of-line colon are already present in `default-site.j2`.

This result in a corrupted Nginx configuration file.