### PR TITLE
Fix PHP default site index block inclusion

### DIFF
--- a/provisioning/roles/nginx/templates/default-site.j2
+++ b/provisioning/roles/nginx/templates/default-site.j2
@@ -6,7 +6,7 @@ server {
     error_log	/var/log/nginx/{{ vhost }}.error.log;
 
     root {{ web_directory }};
-    {% if index %}
+    {% if index or self.index() %}
     index {% block index %}{{ index }}{% endblock %};
     {% endif %}
 
@@ -28,8 +28,8 @@ server {
     error_log	/var/log/nginx/{{ hostname }}.error.log;
 
     root {{ root_directory }};
-    {% if index %}
-    index {{ self.index() }}
+    {% if index or self.index() %}
+    index {{ self.index() }};
     {% endif %}
 
     {{ self.extra() }}


### PR DESCRIPTION
At the moment, if you use `php-fpm`, there’s no index entry added to the Nginx configuration by default even if the sub-template used `php-site.j2` define a block `index`.

This is kinda redundant with the Nginx role `index` parameter which can be useful in other cases.

I’ve made a quick change to add the index block when it is fulfilled whatever `index` value is but I think that’s no ideal. We should be able to merge those two things, no? Any suggestion?

Defining `index` to `index.php` to nginx parameters in `php-fpm` role maybe?