### PR TITLE
Use index block and parameter in nginx as initialy intended.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations/.
 
+## [Unreleased]
+
+### Fixed
+
+- the `index` block in nginx templates now works correctly.
+
 ## [1.0.8] - 2016-10-04
 
 ### Fixed
@@ -176,7 +182,9 @@ Some of the roles still survives today, so not everything was lost ;)
 ## Added
 - Roles : Apache, PHP
 
-[Unreleased]: https://github.com/liip/drifter/compare/v1.0.6...HEAD
+[Unreleased]: https://github.com/liip/drifter/compare/v1.0.8...HEAD
+[1.0.8]: https://github.com/liip/drifter/compare/v1.0.7...v1.0.8
+[1.0.7]: https://github.com/liip/drifter/compare/v1.0.6...v1.0.7
 [1.0.6]: https://github.com/liip/drifter/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/liip/drifter/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/liip/drifter/compare/v1.0.3...v1.0.4

--- a/docs/roles/php.md
+++ b/docs/roles/php.md
@@ -47,6 +47,7 @@ in the NGinx role.
 ## Parameters
 
 * **nginx_site_template**: template to use for site configuration, defaults to "php-site.j2"
+* **nginx_index**: index in nginx configuration, defaults to "index.php"
 
 # PHP-XDebug
 

--- a/provisioning/roles/nginx/templates/default-site.j2
+++ b/provisioning/roles/nginx/templates/default-site.j2
@@ -6,9 +6,11 @@ server {
     error_log	/var/log/nginx/{{ vhost }}.error.log;
 
     root {{ web_directory }};
-    {% if index %}
-    index {% block index %}{{ index }}{% endblock %};
-    {% endif %}
+    {% block index %}
+        {% if index %}
+            index {{ index }};
+        {% endif %}
+    {% endblock %}
 
     {% block extra %}
     {% endblock %}

--- a/provisioning/roles/nginx/templates/php-site.j2
+++ b/provisioning/roles/nginx/templates/php-site.j2
@@ -1,9 +1,5 @@
 {% extends "default-site.j2" %}
 
-{% block index %}
-    index index.php;
-{% endblock %}
-
 {% block extra %}
     {{ super() }}
 

--- a/provisioning/roles/nginx/templates/silex-site.j2
+++ b/provisioning/roles/nginx/templates/silex-site.j2
@@ -1,9 +1,5 @@
 {% extends "default-site.j2" %}
 
-{% block index %}
-    index index.php;
-{% endblock %}
-
 {% block extra %}
     {{ super() }}
 

--- a/provisioning/roles/nginx/templates/symfony2-site.j2
+++ b/provisioning/roles/nginx/templates/symfony2-site.j2
@@ -1,9 +1,5 @@
 {% extends "default-site.j2" %}
 
-{% block index %}
-    index index.php;
-{% endblock %}
-
 {% block extra %}
     {{ super() }}
 

--- a/provisioning/roles/php-fpm/defaults/main.yml
+++ b/provisioning/roles/php-fpm/defaults/main.yml
@@ -1,1 +1,2 @@
 nginx_site_template: "php-site.j2"
+nginx_index: "index.php"

--- a/provisioning/roles/php-fpm/meta/main.yml
+++ b/provisioning/roles/php-fpm/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 dependencies:
   - { role: php }
-  - { role: nginx, site_template: "{{ nginx_site_template }}" }
+  - { role: nginx, site_template: "{{ nginx_site_template }}", index: "{{ nginx_index }}" }


### PR DESCRIPTION
#132 and #133 are real issues due to a bug in the current implementation of the index block. The PR by @LeBenLeBen are totally valid but it is not how the feature was supposed to work.

This is the way I originally intended. Merge the one you prefer :)

* This PR is a :Bugfix
* Link to the related issue if relevant: This should replace #132 and #133 

- [x] Documentation is written
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
