### PR TITLE
Fix solr config folder permissions and Supervisord restart on Wheezy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations/.
 
+## [Unreleased]
+
+### Fixed
+
+- Fix solr config folder permissions and Supervisord restart on Wheezy
+
 ## [1.0.8] - 2016-10-04
 
 ### Fixed

--- a/provisioning/roles/solr/tasks/main.yml
+++ b/provisioning/roles/solr/tasks/main.yml
@@ -17,7 +17,7 @@
   become: yes
 
 - name: SOLR config directory permission
-  file: dest="{{ solr_config_dir }}" state=directory owner=vagrant group=solr mode="g+rwX" recurse=yes
+  file: dest="{{ solr_config_dir }}" state=directory group=solr mode="g+rwX" recurse=yes
   become: yes
 
 - name: SOLR install directory permission

--- a/provisioning/roles/supervisor/handlers/main.yml
+++ b/provisioning/roles/supervisor/handlers/main.yml
@@ -1,5 +1,5 @@
 - name: restart supervisor
-  shell: /etc/init.d/supervisor stop; /etc/init.d/supervisor start
+  shell: /etc/init.d/supervisor stop; /etc/init.d/supervisor start; exit 0
   become: yes
 
 - name: start supervisor


### PR DESCRIPTION
We had issues with those two things while setting up a new Zebra box.

This PR is a : Bugfix

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated