### PR TITLE
retry the mysql-apt-config download and use ssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Changed
 
+- Mysql role: retry 5 times download of mysql-apt-config, if it fails
 - Django role: generate ALLOWED_HOSTS file to comply with Django >= 1.9.11
 
 ## [1.0.9] - 2016-12-02

--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -62,10 +62,14 @@
 
 - name: ensure mysql upstream repository package is downloaded
   get_url:
-    url: http://dev.mysql.com/get/mysql-apt-config_0.8.0-1_all.deb
+    url: https://dev.mysql.com/get/mysql-apt-config_0.8.0-1_all.deb
     dest: /root/mysql-apt-config.deb
   when: mysql_apt_config_check_deb|changed
   become: yes
+  register: get_url_result
+  until: "'OK' in get_url_result.msg"
+  retries: 5
+  delay: 2
 
 - name: ensure mysql upstream repository is installed
   apt:


### PR DESCRIPTION
mysql-apt-config download from dev.mysql.com fails very often with connection reset by peer. So this patch just retries for 5 times in the hope it works once in a while

* This PR is a : Improvement
* Link to the related issue if relevant

- [ ] Documentation is written
- [ ] `parameters.yml.dist` is updated
- [ ] `playbook.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated

