### PR TITLE
 read variables set by drifter into the environment (they're not set,…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Changed
 
+- CI Scripts: Set environment variables set by drifter
 - Django role: generate ALLOWED_HOSTS file to comply with Django >= 1.9.11
 
 ## [1.0.9] - 2016-12-02

--- a/ci/test-header.sh
+++ b/ci/test-header.sh
@@ -5,3 +5,6 @@ finish () {
 }
 
 trap finish EXIT SIGHUP SIGINT SIGTERM
+
+# read variables set by drifter into the environment (they're not set, if not called from bash)
+. /etc/profile.d/drifter_vars.sh


### PR DESCRIPTION
They're not set, if not called from bash

Our standard scripts for gitlab CI don't have some variables (like GITLAB_CI) set. This adds it.

- [ ] Documentation is written
- [ ] `parameters.yml.dist` is updated
- [ ] `playbook.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated

