### PR TITLE
NodeJS: Install GPG key from keyserver.ubuntu.com

### DIFF
--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -9,7 +9,7 @@
   apt: pkg=apt-transport-https state=present
   become: yes
 - name: Add nodesource.com apt key
-  apt_key: id=68576280 url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
+  apt_key: id=68576280 url=https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280 state=present
   become: yes
 - name: Add nodesource.com apt repo
   apt_repository: repo='deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ nodejs_distro}} main' state=present update_cache=yes


### PR DESCRIPTION
deb.nodesource.com is now in CloudFront, and older versions of Python
(such as than installed in Ubuntu 12.04 and 14.04) can no longer install
the GPG key from that server. Instead, install the key from
keyserver.ubuntu.com, and include an ID so that downloading can be
skipped if the key is already installed.

See: https://github.com/nodesource/ansible-nodejs-role/issues/33

* This PR is a : Bugfix