### PR TITLE
Set cache valid-time for apt-update cache command to 1h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Changed
 
+- Base role: Set the cache valid-time for `apt-update cache` command to 1h 
 - Django role: generate ALLOWED_HOSTS file to comply with Django >= 1.9.11
 
 ## [1.0.9] - 2016-12-02

--- a/provisioning/roles/base/tasks/main.yml
+++ b/provisioning/roles/base/tasks/main.yml
@@ -3,8 +3,11 @@
   command: apt-get install -y python-apt creates=/usr/share/pyshared/apt
   become: yes
 
-- name: ensure apt database is up-to-date
-  apt: update_cache=yes
+- name: ensure apt database is up-to-date (cache time 1h)
+  apt:
+    update_cache: yes
+    # Only run "update_cache=yes" if the last one is more than 1h ago (3600 seconds)
+    cache_valid_time: 3600
   become: yes
 
 - name: set en_US.UTF-8 as generated locale


### PR DESCRIPTION
During testing of Drifter provisioning, would be great if we do not update APT cache during each provisioning.
The proposed changes allows the "APT cache" to be kept and not refreshed if it was updated less than one hour ago.

* This PR is a : New feature

- [ ] Documentation is written
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
