### PR TITLE
Solr task: create Solr core and conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ## Unreleased
 
 ### Added
+- Solr role: allow to setup a Solr index/core during the provisioning
 - Virtualbox: allow use of Virtualbox shared folders besides nfs
 
 ### Changed

--- a/docs/roles/java.rst
+++ b/docs/roles/java.rst
@@ -27,8 +27,11 @@ Install ``solr`` via the tarballs available on the Apache repository.
 A specific user is created and ``solr`` is automatically started at boot
 using ``supervisor``.
 
-You can chose any ``solr`` version available via download. However the
-provided start command might need some adjustment.
+You can chose any ``solr`` version (compatible with Java7) via download.
+However the provided start command might need some adjustment.
+
+To create a Solr core use both the ``solr_core_name`` and ``solr_core_conf``
+parameter.
 
 Parameters
 ----------
@@ -46,6 +49,15 @@ want to use a version different than 4.X or 5.X
 -  **solr.config\_dir**: Solr configuration directory, defaults to
    "//solr/"
 -  **solr\_port**: defaults to 8984
+
+-  **solr\_core\_name**: Create a new Solr core/index with such name; by
+   default no indexes are created. Both this parameter and the ``solr_core_conf``
+   must be defined.
+-  **solr\_core\_conf**: Specifies the Solr core/index configuration folder
+   to use for the index, it will be symlink to the `conf` folder of the index,
+   refer to http://lucene.apache.org/solr/ documentation for the file-structure
+   required by Solr.
+   Example: `solr_core_conf=vagrant/solr/conf`.
 
 Internal Parameters
 -------------------

--- a/provisioning/roles/solr/tasks/main.yml
+++ b/provisioning/roles/solr/tasks/main.yml
@@ -16,6 +16,31 @@
   become_user: solr
   become: yes
 
+- name: Add Core directory
+  when: solr_core_name is defined and solr_core_conf is defined
+  file:
+    path: "{{ solr_config_dir}}/{{ solr_core_name}}"
+    state: directory
+  become_user: solr
+  become: yes
+
+- name: Symlink Core conf
+  when: solr_core_name is defined and solr_core_conf is defined
+  file:
+    src: "{{ solr_core_conf }}"
+    dest: "{{ solr_config_dir}}/{{ solr_core_name}}/conf"
+    state: link
+  become_user: solr
+  become: yes
+
+- name: Setup Core properties file
+  when: solr_core_name is defined and solr_core_conf is defined
+  copy:
+    content: "name={{ solr_core_name}}"
+    dest: "{{ solr_config_dir}}/{{ solr_core_name}}/core.properties"
+  become_user: solr
+  become: yes
+
 - name: SOLR config directory permission
   file: dest="{{ solr_config_dir }}" state=directory group=solr mode="g+rwX" recurse=yes
   become: yes


### PR DESCRIPTION
The Solr task allows to have a local Solr instance running. No configuration, no new cores are available during the first run.
This MR allows to define a new core during the provisioning, by using a `conf` directory.

Example usage:

```
- { role: solr, solr_core_name: "core1", solr_core_conf: "/vagrant/my-solr-core-conf" }
```

It will initialize a new Solr core named "core1", where the configuration is symlinked from "/vagrant/myl-solr-core-conf". Useful when working with projects where Solr config could be edited.

In comparison to use the "solr_config_dir" parameter, in this way a project does not need to define the whole Solr configuration folder structure, including the "solr.xml" file.


* This PR is a : Improvement
* Link to the related issue if relevant

- [x] Documentation is written
- [x] ~~`parameters.yml.dist` is updated~~
- [x] ~~`playbook.yml.dist` is updated~~
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated