### PR TITLE
Fix composer installed check: needs sudo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Base role: Set the cache valid-time for `apt-update cache` command to 1h
 - Django role: generate ALLOWED_HOSTS file to comply with Django >= 1.9.11
 
+### Fixed
+- Composer role: don't reinstall on every provision
+
 ## [1.0.9] - 2016-12-02
 
 ### Changed

--- a/provisioning/roles/composer/tasks/main.yml
+++ b/provisioning/roles/composer/tasks/main.yml
@@ -2,7 +2,7 @@
   become: yes
   file: name={{ composer.dir }} state=directory
 
-- command: tests -f {{ composer.dir }}/composer.phar
+- command: test -f {{ composer.dir }}/composer.phar
   register: composer_installed
   ignore_errors: yes
 


### PR DESCRIPTION
Installation is done using root, therefore the check needs to be done also using root.

* This PR is a : Bugfix

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated

A question: what's the difference between `test` and `tests`? I don't recognize the `tests` command.. is that something ansible somehow provides?