### PR TITLE
WIP: Add nginx site template for Laravel projects

### DIFF
--- a/provisioning/roles/nginx/templates/laravel-site.j2
+++ b/provisioning/roles/nginx/templates/laravel-site.j2
@@ -1,0 +1,9 @@
+{% extends "default-site.j2" %}
+
+{% block extra %}
+    {{ super() }}
+
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+{% endblock %}


### PR DESCRIPTION
Add an nginx vhost configuration for Laravel projects. Note the `web_directory` parameter will also need to be adjusted to `/vagrant/public` in `parameters.yml` in every project.

* This PR is a : New feature

- [ ] Documentation is written
- [ ] `parameters.yml.dist` is updated
- [ ] `playbook.yml.dist` is updated
- [ ] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
