### PR TITLE
Node: accept version 7, remove discontinued versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations/.
 
-## In progress
+## Unreleased
 
-### Changed
-- Node role: add support for version 7.x, drop 0.10 and 0.12 (end-of-life)
+### Added
+- Node role: add support for version 7.x
 
 ## [1.1.1] - 2017-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations/.
 
+## In progress
+
+### Changed
+- Node role: add support for version 7.x, drop 0.10 and 0.12 (end-of-life)
+
 ## [1.1.1] - 2017-02-02
 
 ### Fixed

--- a/docs/roles/others.md
+++ b/docs/roles/others.md
@@ -12,7 +12,7 @@ Install NodeJS and NPM.
 
 ## Parameters
 
-* **nodejs_version** : The version to install, currently supports 6.x, 5.x, 4.x, 0.12 and 0.10
+* **nodejs_version** : The version to install, currently supports 7.x, 6.x, 5.x and 4.x, default being 6.x
 * **nodejs_distro** : Is automatically set to either 'jessie' or 'wheezy' based on available information, you can also put an Ubuntu codename here.
 
 # OpenLDAP

--- a/docs/roles/others.md
+++ b/docs/roles/others.md
@@ -12,7 +12,7 @@ Install NodeJS and NPM.
 
 ## Parameters
 
-* **nodejs_version** : The version to install, currently supports 7.x, 6.x, 5.x and 4.x, default being 6.x
+* **nodejs_version** : The version to install, currently supports 7.x, 6.x, 5.x, 4.x, 0.12 and 0.10, default being 6.x.
 * **nodejs_distro** : Is automatically set to either 'jessie' or 'wheezy' based on available information, you can also put an Ubuntu codename here.
 
 # OpenLDAP

--- a/provisioning/roles/nodejs/defaults/main.yml
+++ b/provisioning/roles/nodejs/defaults/main.yml
@@ -7,4 +7,4 @@ nodejs_distro: "{{
 }}"
 nodejs_acceptable_distros: ["wheezy", "jessie", "stretch", "sid", "precise", "trusty"]
 nodejs_version: "6.x"
-nodejs_acceptable_versions: ["7.x", "6.x", "5.x", "4.x"]
+nodejs_acceptable_versions: ["7.x", "6.x", "5.x", "4.x", "0.12", "0.10"]

--- a/provisioning/roles/nodejs/defaults/main.yml
+++ b/provisioning/roles/nodejs/defaults/main.yml
@@ -7,4 +7,4 @@ nodejs_distro: "{{
 }}"
 nodejs_acceptable_distros: ["wheezy", "jessie", "stretch", "sid", "precise", "trusty"]
 nodejs_version: "6.x"
-nodejs_acceptable_versions: ["6.x", "5.x", "4.x", "0.12", "0.10"]
+nodejs_acceptable_versions: ["7.x", "6.x", "5.x", "4.x"]


### PR DESCRIPTION
Allow to use Node 7 which has been released a while ago. Remove support for Node 0.10 and 0.12 which are both [discontinued](https://github.com/nodejs/LTS#lts-schedule).

* This PR is a : Improvement

- [x] Documentation is written
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
