### PR TITLE
Improve upgrades of MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Fixed
 - MySQL role: fix installation of MySQL packages by upgrading mysql-apt-config
 - php-memcached role: Fix the memcached extension installation for debian
+- MySQL role: improve upgrades of MySQL by executing mysql_upgrade
 
 ## [1.1.1] - 2017-02-02
 

--- a/provisioning/roles/mysql/defaults/main.yml
+++ b/provisioning/roles/mysql/defaults/main.yml
@@ -1,3 +1,5 @@
 database_user: "{{ database_name }}"
 database_password: "{{ database_name }}"
 mysql_version: 5.6
+mysql_apt_config_version: 0.8.3
+mysql_apt_config_patchlevel: 1

--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -57,7 +57,7 @@
   command: dpkg-query -W mysql-apt-config
   register: mysql_apt_config_check_deb
   failed_when: mysql_apt_config_check_deb.rc > 1
-  changed_when: mysql_apt_config_check_deb.rc == 1
+  changed_when: mysql_apt_config_check_deb.rc == 1 or '0.8.2' not in mysql_apt_config_check_deb.stdout
   become: yes
 
 - name: ensure mysql upstream repository package is downloaded
@@ -121,6 +121,13 @@
     name: mysql
     state: started
     enabled: yes
+  become: yes
+
+- name: ensure mysql data is upgraded
+  command: mysql_upgrade
+  register: mysql_upgrade
+  failed_when: mysql_upgrade.rc != 0 and mysql_upgrade.stdout.find('already upgraded') == -1
+  changed_when: mysql_upgrade.stdout.find('already upgraded') == -1
   become: yes
 
 - name: create database user

--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -57,12 +57,12 @@
   command: dpkg-query -W mysql-apt-config
   register: mysql_apt_config_check_deb
   failed_when: mysql_apt_config_check_deb.rc > 1
-  changed_when: mysql_apt_config_check_deb.rc == 1 or '0.8.2' not in mysql_apt_config_check_deb.stdout
+  changed_when: mysql_apt_config_check_deb.rc == 1 or '{{mysql_apt_config_version}}' not in mysql_apt_config_check_deb.stdout
   become: yes
 
 - name: ensure mysql upstream repository package is downloaded
   get_url:
-    url: http://dev.mysql.com/get/mysql-apt-config_0.8.2-1_all.deb
+    url: http://dev.mysql.com/get/mysql-apt-config_{{mysql_apt_config_version}}-{{mysql_apt_config_patchlevel}}_all.deb
     dest: /root/mysql-apt-config.deb
   when: mysql_apt_config_check_deb|changed
   become: yes


### PR DESCRIPTION
With comparing the version of the installed mysql-apt-config it can also be updated when it's not the version we try to install.

Running `mysql_upgrade` after the installation helps upgrading an existing installation, for example from version 5.6 to 5.7. Otherwise it will fail creating the user due to changes in mysql.user.