### PR TITLE
Updated mysql-apt-config package version

### DIFF
--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -62,7 +62,7 @@
 
 - name: ensure mysql upstream repository package is downloaded
   get_url:
-    url: http://dev.mysql.com/get/mysql-apt-config_0.8.2-1_all.deb
+    url: http://dev.mysql.com/get/mysql-apt-config_0.8.3-1_all.deb
     dest: /root/mysql-apt-config.deb
   when: mysql_apt_config_check_deb|changed
   become: yes


### PR DESCRIPTION
The mysql-apt-config deb uses an outdated GPG key, the new version `0.8.3` seems to fix that.
