### PR TITLE
ON HOLD: Added a new role to install a current version of WKHTMLTOPDF

### DIFF
--- a/playground/playbook.yml
+++ b/playground/playbook.yml
@@ -51,6 +51,9 @@
     ## Install the ssh rule, installs gitlab.liip.ch and github.com host key
     # - { role: ssh }
 
+    # Install WKHTMLTOPDF
+    # - { role: wkhtmltopdf }
+
     ## Install some Gitlab CI scripts and .gitlab-ci.yml.
     ## See https://github.com/liip/drifter/blob/master/ci/README.md for details
     # - { role: gitlabci }

--- a/playground/playbook.yml
+++ b/playground/playbook.yml
@@ -22,6 +22,9 @@
     # - { role: mysql }
     # - { role: postgresql }
 
+    # Install WKHTMLTOPDF
+    # - { role: wkhtmltopdf }
+
     ## Scripting / Language support
     # - { role: php-fpm }       # PHP using Nginx and PHP-FPM
     # - { role: php-apache }    # PHP using Apache and mod-php
@@ -50,9 +53,6 @@
 
     ## Install the ssh rule, installs gitlab.liip.ch and github.com host key
     # - { role: ssh }
-
-    # Install WKHTMLTOPDF
-    # - { role: wkhtmltopdf }
 
     ## Install some Gitlab CI scripts and .gitlab-ci.yml.
     ## See https://github.com/liip/drifter/blob/master/ci/README.md for details

--- a/provisioning/playbook.yml.dist
+++ b/provisioning/playbook.yml.dist
@@ -22,6 +22,9 @@
     # - { role: mysql }
     # - { role: postgresql }
 
+    # Install WKHTMLTOPDF
+    # - { role: wkhtmltopdf }
+
     ## Scripting / Language support
     # - { role: php-fpm }       # PHP using Nginx and PHP-FPM
     # - { role: php-apache }    # PHP using Apache and mod-php

--- a/provisioning/roles/django/handlers/main.yml
+++ b/provisioning/roles/django/handlers/main.yml
@@ -1,0 +1,4 @@
+# If WKHTMLTOPDF was installed, set the env variable
+- name: WKHTMLTOPDF installed
+  copy: content="/opt/wkhtmltox/bin/wkhtmltopdf" dest="{{ django_root }}/envdir/WKHTMLTOPDF"
+

--- a/provisioning/roles/django/tasks/main.yml
+++ b/provisioning/roles/django/tasks/main.yml
@@ -28,3 +28,4 @@
 - name: migrate
   command: "{{ env_root }}/bin/python {{ django_root }}/manage.py migrate --noinput"
   when: database_type is defined
+

--- a/provisioning/roles/wkhtmltopdf/defaults/main.yml
+++ b/provisioning/roles/wkhtmltopdf/defaults/main.yml
@@ -1,0 +1,6 @@
+version: "0.12/0.12.4"
+filename: "wkhtmltox-0.12.4_linux-generic-amd64.tar.xz"
+
+# this is not very useful yet, but their URL is built like this
+url: "http://download.gna.org/wkhtmltopdf/{{ version }}/{{ filename }}"
+dst: "/opt/"

--- a/provisioning/roles/wkhtmltopdf/tasks/main.yml
+++ b/provisioning/roles/wkhtmltopdf/tasks/main.yml
@@ -2,10 +2,12 @@
 - name: download wkhtmltopdf package
   get_url: url={{ url }} dest={{ dst }}/{{ filename }}
   sudo: yes
-  register: downloaded
+  register: wkhtmltopdf_downloaded
 
 
 - name: unzip wkhtmltopdf package
   unarchive: src={{ dst }}/{{ filename }} dest={{ dst }} copy=no
   sudo: yes
-  when: downloaded
+  when: wkhtmltopdf_downloaded
+  register: wkhtmltopdf_installed
+  notify: WKHTMLTOPDF installed

--- a/provisioning/roles/wkhtmltopdf/tasks/main.yml
+++ b/provisioning/roles/wkhtmltopdf/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: download wkhtmltopdf package
+  get_url: url={{ url }} dest={{ dst }}/{{ filename }}
+  sudo: yes
+  register: downloaded
+
+
+- name: unzip wkhtmltopdf package
+  unarchive: src={{ dst }}/{{ filename }} dest={{ dst }} copy=no
+  sudo: yes
+  when: downloaded


### PR DESCRIPTION
We often use WKHTMLTOPDF in team Amboss, but the one available in the repos is outdated.
I wrote a new role for drifter in order to install a more up to date version of it.

In order for django to work with wkhtmltopdf an environment variable needs to be set. I hope I did that the right way by using handlers, I only wanted it to be written when wkhtmltopdf is installed.

I will write the documentation and changelog when you can tell me that the idea behind this feature is OK.
