### PR TITLE
set threshold for time jumping to 10 seconds instead of default 20 mi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Gulp role: Specify SSL certificates in BrowserSync config when role SSL is installed
 - Gulp role: Print WebPack/Sass compilation to the browser
 - Ruby role: add instructions on how to setup Drifter for Rails projects
+- Virtualbox: Set timesync-set-threshold to 10 seconds instead of the default 20 minutes
 
 ### Changed
 - PHP role: set `always_populate_raw_post_data` to -1 to avoid deprecation warnings

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,6 +92,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         v.cpus = 2
         v.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
         v.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
+        # From the manual:
+        # The absolute drift threshold, given as milliseconds where to start setting the time instead of trying to smoothly adjust it. The default is 20 minutes.
+        # we set it here to 10 seconds, I had too many way off time, which screwed up some digital signatures.
+        v.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
 
         if Vagrant.has_plugin?("vagrant-cachier")
             # use the same nfs config than above for cache performance


### PR DESCRIPTION
…nutes

It was too many times way off and screwed my digital signatures.

* This PR is a :Improvement

- [ ] Documentation is written
- [ ] `parameters.yml.dist` is updated
- [ ] `playbook.yml.dist` is updated
- [x ] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
