### PR TITLE
Made installation of php-memcached work on Debian as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Fixed
 - MySQL role: fix installation of MySQL packages by upgrading mysql-apt-config
+- php-memcached role: Fix the memcached extension installation for debian
 
 ## [1.1.1] - 2017-02-02
 

--- a/provisioning/roles/php-memcached/meta/main.yml
+++ b/provisioning/roles/php-memcached/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 dependencies:
+  - { role: php-fpm }
   - { role: memcached }
   - { role: php }

--- a/provisioning/roles/php-memcached/meta/main.yml
+++ b/provisioning/roles/php-memcached/meta/main.yml
@@ -1,5 +1,4 @@
 ---
 dependencies:
-  - { role: php-fpm }
   - { role: memcached }
   - { role: php }

--- a/provisioning/roles/php-memcached/tasks/main.yml
+++ b/provisioning/roles/php-memcached/tasks/main.yml
@@ -7,9 +7,8 @@
    - "default.yml"
 
 - name: install PHP {{ php_version_installed }} memcached extension
-  apt: pkg={{ item }} state=latest
+  apt: pkg={{ php_memcached_package }} state=latest
   become: yes
-  with_items: "{{ php_packages }}"
 
 - name: Activate PHP configuration files
   command: "{{ phpenmod }} -s ALL {{ item }}"

--- a/provisioning/roles/php-memcached/tasks/main.yml
+++ b/provisioning/roles/php-memcached/tasks/main.yml
@@ -1,9 +1,18 @@
-- name: install PHP memcached extension
-  apt: pkg=php-memcached state=latest
+- include_vars: "default.yml"
+
+- include_vars: "{{ item }}"
+  with_first_found:
+   - "{{ ansible_distribution }}-{{ php_version_installed }}.yml"
+   - "{{ ansible_distribution }}.yml"
+   - "default.yml"
+
+- name: install PHP {{ php_version_installed }} memcached extension
+  apt: pkg={{ item }} state=latest
   become: yes
+  with_items: "{{ php_packages }}"
 
 - name: Activate PHP configuration files
-  command: "{{phpenmod}} -s ALL {{ item }}"
+  command: "{{ phpenmod }} -s ALL {{ item }}"
   with_items:
     - memcached
   notify:

--- a/provisioning/roles/php-memcached/vars/Debian-7.0.yml
+++ b/provisioning/roles/php-memcached/vars/Debian-7.0.yml
@@ -1,1 +1,1 @@
-memcache_package: php7.0-memcached
+php_memcached_package: php7.0-memcached

--- a/provisioning/roles/php-memcached/vars/Debian-7.0.yml
+++ b/provisioning/roles/php-memcached/vars/Debian-7.0.yml
@@ -1,0 +1,1 @@
+memcache_package: php7.0-memcached

--- a/provisioning/roles/php-memcached/vars/Ubuntu.yml
+++ b/provisioning/roles/php-memcached/vars/Ubuntu.yml
@@ -1,2 +1,2 @@
 # On ubuntu the packages are called the same
-memcache_package: php-memcached
+php_memcached_package: php-memcached

--- a/provisioning/roles/php-memcached/vars/Ubuntu.yml
+++ b/provisioning/roles/php-memcached/vars/Ubuntu.yml
@@ -1,0 +1,2 @@
+# On ubuntu the packages are called the same
+memcache_package: php-memcached

--- a/provisioning/roles/php-memcached/vars/default.yml
+++ b/provisioning/roles/php-memcached/vars/default.yml
@@ -1,5 +1,2 @@
 # Debian package name. Default b/c debian is default
-memcache_package: php5-memcached
-
-php_packages:
-  - "{{ memcache_package }}"
+php_memcached_package: php5-memcached

--- a/provisioning/roles/php-memcached/vars/default.yml
+++ b/provisioning/roles/php-memcached/vars/default.yml
@@ -1,0 +1,5 @@
+# Debian package name. Default b/c debian is default
+memcache_package: php5-memcached
+
+php_packages:
+  - "{{ memcache_package }}"

--- a/provisioning/roles/php-xdebug/tasks/main.yml
+++ b/provisioning/roles/php-xdebug/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: install PHP packages
   apt: pkg={{ item }} state=latest
   become: yes
-  with_items: "{{ php_packages }}" 
+  with_items: "{{ php_packages }}"
 
 
 - include: not-debian-7.0.yml


### PR DESCRIPTION
Made php-memcached role aware of the distro (Ubuntu/Debian) specific package names.
Specifically:
* Ubuntu: php-memcached (Apparently Ubuntu can handle both versions with the same package)
* Debian:
    * php5.6: php5-memcached
    * php7.0: php7.0-memcached

Other versions are not handled, but as far as I understand, Drifter only supports those versions **Is this correct**?

* This PR is a : Bugfix
Fixes #121

- [ ] Documentation is written: _Not needed in my opinion_
- [ ] `parameters.yml.dist` is updated: _Not needed in my opinion_
- [ ] `playbook.yml.dist` is updated: _Not needed in my opinion_
- [X] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
