### PR TITLE
Small fixes for the ruby role

### DIFF
--- a/docs/roles/others.md
+++ b/docs/roles/others.md
@@ -1,11 +1,3 @@
-# Ruby
-
-Install Ruby, Gem integration for Debian and dev dependencies.
-
-Any Debian ruby package should then be also recognized as a Gem. You can however
-continue to install Gems using the `gem` utility if you need a specific version
-or an unavailable package.
-
 # NodeJS
 
 Install NodeJS and NPM.

--- a/provisioning/roles/ruby/tasks/main.yml
+++ b/provisioning/roles/ruby/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 - name: make sure libreadline-dev is installed
-  apt:
-    pkg: libreadline-dev
-    state: installed
-  sudo: yes
+  apt: pkg={{ item }} state=latest
+  become: yes
+  with_items:
+    - libreadline-dev
+    - libsqlite3-dev
 
 - name: install rbenv
   git:
@@ -50,8 +51,7 @@
   copy:
     dest: ~/.gemrc
     content: |
-        +install: --no-rdoc --no-ri
-        +update: --no-rdoc --no-ri
+      install: --no-document
 
 - name: Install bundler
   command: ~/.rbenv/shims/gem install bundler


### PR DESCRIPTION
Remove deprecated documentation + setup sqlite3-dev package (used by sqlite3 gem used in default rails install) + update gemrc