### PR TITLE
Feature browser roles for end to end tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Nginx role: fix Drupal templates and rewrite rule
 
 ### Added
+- Add `phantomjs` role to install a specific phantomJS version
 - Add `firefox` role to install a specific version or the latest Firefox version
 - Add `chrome` role to install the Chrome browser
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ For migration information, you can always have a look at https://liip-drifter.re
 - MySQL role: don't install mysql upstream repository if a newer version is already installed.
 - Nginx role: fix Drupal templates and rewrite rule
 
+### Added
+- Add `firefox` role to install a specific version or the latest Firefox version
+- Add `chrome` role to install the Chrome browser
+
 ## [1.3.0] - 2017-04-26
 
 ### Added

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,6 +80,7 @@ anywhere else you'd like to.
     roles/ruby
     roles/java
     roles/frontend
+    roles/browsers
     roles/others
 
 .. toctree::

--- a/docs/roles/browsers.rst
+++ b/docs/roles/browsers.rst
@@ -3,7 +3,7 @@ Browser Roles
 *************
 
 Browser roles are available for frontend testing. They all depend on
-the role xvfb, which is a headless X server.
+the role xvfb, which is a headless X server, except for Phantomjs.
 
 
 Firefox
@@ -30,6 +30,12 @@ There are no parameters available for this one, as they don't really provide
 older versions. Therefore, always the newest Chrome browser will be installed.
 
 
+PhantomJS
+=========
+
+Install PhantomJS
+
+
 Example usage with pytest and splinter
 ======================================
 
@@ -43,9 +49,10 @@ this):
 
 - pytest
 - pytest-splinter
-- pytest-xvfb
+- pytest-xvfb (When you want to use firefox or chrome)
 
 
 In order to run your tests, you can simply invoke pytest. By default the
 Firefox webdriver will be used, but it's possible to change this with the
-option --splinter-webdriver=chrome.
+option --splinter-webdriver=chrome. More info available
+[here](https://github.com/pytest-dev/pytest-splinter).

--- a/docs/roles/browsers.rst
+++ b/docs/roles/browsers.rst
@@ -1,0 +1,51 @@
+*************
+Browser Roles
+*************
+
+Browser roles are available for frontend testing. They all depend on
+the role xvfb, which is a headless X server.
+
+
+Firefox
+=======
+
+Install Firefox with Geckodriver to be used with selenium.
+
+
+Parameters
+----------
+
+* **firefox\_version** : The
+  [version](https://ftp.mozilla.org/pub/firefox/releases/) of Firefox to
+  be installed, defaults to 'latest'. Should be greater than 47.0.:w
+
+
+
+Chrome
+======
+
+Install Chrome with Chromedriver to be used with selenium.
+
+There are no parameters available for this one, as they don't really provide
+older versions. Therefore, always the newest Chrome browser will be installed.
+
+
+Example usage with pytest and splinter
+======================================
+
+This is the recommended way to use those browser for testing in python with
+*pytest*. *pytest-splinter* is a pytest plugin that provides easy access to
+several webdrivers.
+
+First, you have to install some packages via pip
+(see :ref:`virtualenv-reference-label` for instruction on how to properly do
+this):
+
+- pytest
+- pytest-splinter
+- pytest-xvfb
+
+
+In order to run your tests, you can simply invoke pytest. By default the
+Firefox webdriver will be used, but it's possible to change this with the
+option --splinter-webdriver=chrome.

--- a/docs/roles/python.rst
+++ b/docs/roles/python.rst
@@ -17,6 +17,7 @@ Parameters
 
 -  **python\_version**: Either version 2 or 3, defaults to "2"
 
+ .. _virtualenv-reference-label:
 Virtualenv
 ==========
 

--- a/provisioning/playbook.yml.dist
+++ b/provisioning/playbook.yml.dist
@@ -58,9 +58,10 @@
     ## See https://github.com/liip/drifter/blob/master/ci/README.md for details
     # - { role: gitlabci }
 
-    # Install Browsers for frontend testing
+    # Install Browsers for end-to-end tests
     # - { role: firefox }
     # - { role: chrome }
+    # - { role: phantomjs }
 
     ## You can also creates your own role, just add a directory under the 'virtualization'
     ## folder and refer to it like for other roles :

--- a/provisioning/playbook.yml.dist
+++ b/provisioning/playbook.yml.dist
@@ -58,6 +58,10 @@
     ## See https://github.com/liip/drifter/blob/master/ci/README.md for details
     # - { role: gitlabci }
 
+    # Install Browsers for frontend testing
+    # - { role: firefox }
+    # - { role: chrome }
+
     ## You can also creates your own role, just add a directory under the 'virtualization'
     ## folder and refer to it like for other roles :
     # - { role: my_own_role }

--- a/provisioning/roles/chrome/defaults/main.yml
+++ b/provisioning/roles/chrome/defaults/main.yml
@@ -1,0 +1,4 @@
+# currently only the latest version is supported
+chrome_download_url: https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+
+chromedriver_download_url: https://chromedriver.storage.googleapis.com/2.28/chromedriver_linux64.zip

--- a/provisioning/roles/chrome/meta/main.yml
+++ b/provisioning/roles/chrome/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: xvfb }

--- a/provisioning/roles/chrome/tasks/main.yml
+++ b/provisioning/roles/chrome/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Install Chrome
+  apt: deb={{ chrome_download_url }} state=present
+  sudo: yes
+
+- name: Download Chromedriver
+  get_url: url={{ chromedriver_download_url }} dest=/opt/chromedriver.zip
+  sudo: yes
+
+- name: Create directory for chromedriver
+  file: path=/opt/chromedriver state=directory
+  sudo: yes
+
+- name: Unzip Chromedriver
+  unarchive: src=/opt/chromedriver.zip dest=/opt/chromedriver/ creates=/opt/chromedriver/chromedriver
+  sudo: yes
+
+- name: Symlink Chrome
+  file: state=link src=/opt/chromedriver/chromedriver path=/usr/bin/chromedriver
+  sudo: yes

--- a/provisioning/roles/firefox/defaults/main.yml
+++ b/provisioning/roles/firefox/defaults/main.yml
@@ -1,0 +1,2 @@
+# default version
+firefox_version: latest

--- a/provisioning/roles/firefox/meta/main.yml
+++ b/provisioning/roles/firefox/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: xvfb }

--- a/provisioning/roles/firefox/tasks/main.yml
+++ b/provisioning/roles/firefox/tasks/main.yml
@@ -21,17 +21,17 @@
   sudo: yes
 
 - name: Download geckodriver {{ geckodriver_version }}
-  get_url: url={{ geckodriver_download_url }} dest=/opt/geckodriver.tar.gz
+  get_url: url={{ geckodriver_download_url }} dest=/opt/geckodriver-{{ geckodriver_version }}.tar.gz
   sudo: yes
 
 - name: Make directory for geckodriver
-  file: path=/opt/geckodriver state=directory
+  file: path=/opt/geckodriver-{{ geckodriver_version }} state=directory
   sudo: yes
 
 - name: Unpack Geckodriver
-  unarchive: src=/opt/geckodriver.tar.gz dest=/opt/geckodriver/ copy=no
+  unarchive: src=/opt/geckodriver-{{ geckodriver_version }}.tar.gz dest=/opt/geckodriver-{{ geckodriver_version }}/ copy=no
   sudo: yes
 
 - name: Create Geckodriver Symlinks
-  file: state=link src=/opt/geckodriver/geckodriver path=/usr/bin/geckodriver
+  file: state=link src=/opt/geckodriver-{{ geckodriver_version }}/geckodriver path=/usr/bin/geckodriver
   sudo: yes

--- a/provisioning/roles/firefox/tasks/main.yml
+++ b/provisioning/roles/firefox/tasks/main.yml
@@ -1,0 +1,37 @@
+- name: Install Firefox dependencies
+  apt: name={{ firefox_dependencies }} state=present
+  sudo: yes
+
+- name: Download latest Firefox
+  get_url: url={{ firefox_latest_url }} dest=/opt/firefox.tar.bz2
+  sudo: yes
+  when: firefox_version == 'latest'
+
+- name: Download Firefox {{ firefox_version }}
+  get_url: url={{ firefox_download_url }} dest=/opt/firefox.tar.bz2
+  sudo: yes
+  when: firefox_version != 'latest'
+
+- name: Unpack Firefox
+  unarchive: src=/opt/firefox.tar.bz2 dest=/opt/ copy=no creates=/opt/firefox/
+  sudo: yes
+
+- name: Create Firefox Symlinks
+  file: state=link src=/opt/firefox/firefox path=/usr/bin/firefox
+  sudo: yes
+
+- name: Download geckodriver {{ geckodriver_version }}
+  get_url: url={{ geckodriver_download_url }} dest=/opt/geckodriver.tar.gz
+  sudo: yes
+
+- name: Make directory for geckodriver
+  file: path=/opt/geckodriver state=directory
+  sudo: yes
+
+- name: Unpack Geckodriver
+  unarchive: src=/opt/geckodriver.tar.gz dest=/opt/geckodriver/ copy=no
+  sudo: yes
+
+- name: Create Geckodriver Symlinks
+  file: state=link src=/opt/geckodriver/geckodriver path=/usr/bin/geckodriver
+  sudo: yes

--- a/provisioning/roles/firefox/vars/main.yml
+++ b/provisioning/roles/firefox/vars/main.yml
@@ -1,0 +1,14 @@
+firefox_dependencies:
+  - libgtk-3-0
+  - libdbus-glib-1-2
+
+# This URL downloads the latest version
+firefox_latest_url: https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US
+
+# This URL is used for a specific version download
+firefox_download_url: https://ftp.mozilla.org/pub/firefox/releases/{{ firefox_version }}/linux-x86_64/en-US/firefox-{{ firefox_version }}.tar.bz2
+
+geckodriver_version: 0.15.0
+
+geckodriver_download_url: https://github.com/mozilla/geckodriver/releases/download/v{{ geckodriver_version }}/geckodriver-v{{ geckodriver_version }}-linux64.tar.gz
+

--- a/provisioning/roles/firefox/vars/main.yml
+++ b/provisioning/roles/firefox/vars/main.yml
@@ -8,7 +8,7 @@ firefox_latest_url: https://download.mozilla.org/?product=firefox-latest&os=linu
 # This URL is used for a specific version download
 firefox_download_url: https://ftp.mozilla.org/pub/firefox/releases/{{ firefox_version }}/linux-x86_64/en-US/firefox-{{ firefox_version }}.tar.bz2
 
-geckodriver_version: 0.15.0
+geckodriver_version: 0.18.0
 
 geckodriver_download_url: https://github.com/mozilla/geckodriver/releases/download/v{{ geckodriver_version }}/geckodriver-v{{ geckodriver_version }}-linux64.tar.gz
 

--- a/provisioning/roles/phantomjs/defaults/main.yml
+++ b/provisioning/roles/phantomjs/defaults/main.yml
@@ -1,0 +1,1 @@
+phantomjs_version: 2.1.1

--- a/provisioning/roles/phantomjs/tasks/main.yml
+++ b/provisioning/roles/phantomjs/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: Download phantomjs
+  get_url: url={{ phantomjs_url }} dest=/opt/phantomjs.tar.bz2
+  sudo: yes
+
+- name: Unpack phantomjs
+  unarchive: src=/opt/phantomjs.tar.bz2 dest=/opt/ copy=no creates=/opt/{{ phantomjs_name }}/
+  sudo: yes
+
+- name: Create phantomjs Symlink
+  file: state=link src=/opt/{{ phantomjs_name }}/bin/phantomjs path=/usr/bin/phantomjs
+  sudo: yes

--- a/provisioning/roles/phantomjs/vars/main.yml
+++ b/provisioning/roles/phantomjs/vars/main.yml
@@ -1,0 +1,5 @@
+phantomjs_name: phantomjs-{{ phantomjs_version }}-linux-x86_64
+
+phantomjs_filename: "{{ phantomjs_name }}.tar.bz2"
+
+phantomjs_url: https://bitbucket.org/ariya/phantomjs/downloads/{{ phantomjs_filename }}

--- a/provisioning/roles/xvfb/tasks/main.yml
+++ b/provisioning/roles/xvfb/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Install xvfb
+  apt: name=xvfb state=present
+  sudo: yes


### PR DESCRIPTION
Added roles for Firefox and Chrome browser

We would like to test our frontends via selenium (pytest, pytest-splinter to be precise) and need those browsers to be ready in drifter.

* This PR is a : New feature
* Link to the related issue if relevant

- [X] Documentation is written
- [ ] `parameters.yml.dist` is updated
- [X] `playbook.yml.dist` is updated
- [X] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
