### PR TITLE
Virtualbox: allow use of vagrant default synced folders implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ## Unreleased
 
 ### Added
+- Virtualbox: allow use of the vagrant default synced folders implementation.
 - Virtualenv role: add `pip_requirements_dir` option to automatically compile `.in` requirements
 
 ## [1.2.0] - 2017-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ## Unreleased
 
 ### Added
-- Virtualbox: allow use of the vagrant default synced folders implementation.
+- Virtualbox: allow use of Virtualbox shared folders besides nfs
 - Virtualenv role: add `pip_requirements_dir` option to automatically compile `.in` requirements
 
 ## [1.2.0] - 2017-03-28

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,6 +46,15 @@ else
     Vagrant.require_version ">= 1.6.2"
 end
 
+synced_folder_type = custom_config.get('synced_folder_type')
+
+unless (synced_folder_type == "nfs" || synced_folder_type == "virtualbox")
+    class SyncedFolderTypeError < Vagrant::Errors::VagrantError
+        self.error_message "[synced_folder_type] Only 'nfs' and 'virtualbox' are supported values"
+    end
+    raise SyncedFolderTypeError
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = custom_config.get('box_name', 'drifter/jessie64-base')
     box_url = custom_config.get('box_url', 'https://vagrantbox-public.liip.ch/drifter-jessie64-base.json')
@@ -78,9 +87,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider "virtualbox" do |v, override|
         override.vm.network :private_network, ip: custom_config.get('box_ip', "10.10.10.10")
 
-        sync_type = custom_config.get('sync_type')
-
-        if sync_type == "nfs"
+        if synced_folder_type == "nfs"
             if Vagrant::Util::Platform.windows? && !Vagrant.has_plugin?("vagrant-winnfsd")
                 puts "*************************************************************************"
                 puts "Please install the plugin vagrant-winnfsd to have NFS Support on Windows!"
@@ -101,7 +108,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # we set it here to 10 seconds, I had too many way off time, which screwed up some digital signatures.
         v.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
 
-        if Vagrant.has_plugin?("vagrant-cachier") && sync_type == "nfs"
+        if Vagrant.has_plugin?("vagrant-cachier") && synced_folder_type == "nfs"
             # use the same nfs config than above for cache performance
              override.cache.synced_folder_opts = {type: "nfs", mount_options: ['noatime', 'noacl', 'proto=udp', 'vers=3', 'async', 'actimeo=1']}
         end

--- a/Vagrantfile.dist
+++ b/Vagrantfile.dist
@@ -31,6 +31,7 @@ class CustomConfig
   attr_accessor :extra_vars      # extra variables to pass to Ansible
 
   attr_accessor :forwarded_ports # Port that need to be forwarded
+  attr_accessor :sync_type       # Type of synced folder to use
 
   # Retrieve the values of 'virtualization/parameters.yml' so that
   # they can be used by Vagrant. If you need to change those values
@@ -52,6 +53,7 @@ class CustomConfig
     @extra_vars    = {}
 
     @forwarded_ports = config['forwarded_ports'] || nil
+    @sync_type       = config['sync_type'] || "nfs"
   end
 
   # Getter that first check if the accessor exists on the class and if

--- a/Vagrantfile.dist
+++ b/Vagrantfile.dist
@@ -18,20 +18,20 @@ class CustomConfig
   # you can delete the 'attr_accessor' and provide your own method
   # to return the values.
 
-  attr_accessor :box_name        # url of the lxc box
-  attr_accessor :box_url         # name of the lxc box
+  attr_accessor :box_name           # url of the lxc box
+  attr_accessor :box_url            # name of the lxc box
 
-  attr_accessor :project_name    # project name (currently unused by the Vagrant file)
-  attr_accessor :hostname        # main hostname of the box
-  attr_accessor :hostnames       # alternative hostnames (array)
-  attr_accessor :box_ip          # IP of the box
+  attr_accessor :project_name       # project name (currently unused by the Vagrant file)
+  attr_accessor :hostname           # main hostname of the box
+  attr_accessor :hostnames          # alternative hostnames (array)
+  attr_accessor :box_ip             # IP of the box
 
-  attr_accessor :ansible_local   # use 'ansible_local' provisionner ?
-  attr_accessor :playbook        # path to the playbook
-  attr_accessor :extra_vars      # extra variables to pass to Ansible
+  attr_accessor :ansible_local      # use 'ansible_local' provisionner ?
+  attr_accessor :playbook           # path to the playbook
+  attr_accessor :extra_vars         # extra variables to pass to Ansible
 
-  attr_accessor :forwarded_ports # Port that need to be forwarded
-  attr_accessor :sync_type       # Type of synced folder to use
+  attr_accessor :forwarded_ports    # Port that need to be forwarded
+  attr_accessor :synced_folder_type # Type of synced folder to use
 
   # Retrieve the values of 'virtualization/parameters.yml' so that
   # they can be used by Vagrant. If you need to change those values
@@ -52,8 +52,8 @@ class CustomConfig
     @playbook      = config['playbook'] || nil
     @extra_vars    = {}
 
-    @forwarded_ports = config['forwarded_ports'] || nil
-    @sync_type       = config['sync_type'] || "nfs"
+    @forwarded_ports    = config['forwarded_ports'] || nil
+    @synced_folder_type = config['synced_folder_type'] || "nfs"
   end
 
   # Getter that first check if the accessor exists on the class and if

--- a/parameters.yml.dist
+++ b/parameters.yml.dist
@@ -28,9 +28,10 @@ database_name: "example"
 # Root directory of your project for the webserver and other purposes
 root_directory: "/vagrant/"
 
-# Synced folder type to use. Only "nfs" and "" will work. Default in drifter
-# is "nfs". Uncomment the following line to use the vagrant default.
-# sync_type: ""
+# Synced folder type to use. Only "nfs" and "virtualbox" are supported by
+# drifter. Defaults to "nfs". Uncomment the following line to use the
+# Virtualbox shared folder implementation.
+# synced_folder_type: "virtualbox"
 
 # Do we activate SSL ? The CA will be copied to your project dir, you can then
 # add it to your computer keychain

--- a/parameters.yml.dist
+++ b/parameters.yml.dist
@@ -28,6 +28,10 @@ database_name: "example"
 # Root directory of your project for the webserver and other purposes
 root_directory: "/vagrant/"
 
+# Synced folder type to use. Only "nfs" and "" will work. Default in drifter
+# is "nfs". Uncomment the following line to use the vagrant default.
+# sync_type: ""
+
 # Do we activate SSL ? The CA will be copied to your project dir, you can then
 # add it to your computer keychain
 # ssl: yes

--- a/playground/Vagrantfile
+++ b/playground/Vagrantfile
@@ -18,19 +18,20 @@ class CustomConfig
   # you can delete the 'attr_accessor' and provide your own method
   # to return the values.
 
-  attr_accessor :box_name        # url of the lxc box
-  attr_accessor :box_url         # name of the lxc box
+  attr_accessor :box_name           # url of the lxc box
+  attr_accessor :box_url            # name of the lxc box
 
-  attr_accessor :project_name    # project name (currently unused by the Vagrant file)
-  attr_accessor :hostname        # main hostname of the box
-  attr_accessor :hostnames       # alternative hostnames (array)
-  attr_accessor :box_ip          # IP of the box
+  attr_accessor :project_name       # project name (currently unused by the Vagrant file)
+  attr_accessor :hostname           # main hostname of the box
+  attr_accessor :hostnames          # alternative hostnames (array)
+  attr_accessor :box_ip             # IP of the box
 
-  attr_accessor :ansible_local   # use 'ansible_local' provisionner ?
-  attr_accessor :playbook        # path to the playbook
-  attr_accessor :extra_vars      # extra variables to pass to Ansible
+  attr_accessor :ansible_local      # use 'ansible_local' provisionner ?
+  attr_accessor :playbook           # path to the playbook
+  attr_accessor :extra_vars         # extra variables to pass to Ansible
 
-  attr_accessor :forwarded_ports # Port that need to be forwarded
+  attr_accessor :forwarded_ports    # Port that need to be forwarded
+  attr_accessor :synced_folder_type # Type of synced folder to use
 
   # Retrieve the values of 'virtualization/parameters.yml' so that
   # they can be used by Vagrant. If you need to change those values
@@ -51,7 +52,8 @@ class CustomConfig
     @playbook      = config['playbook'] || nil
     @extra_vars    = {}
 
-    @forwarded_ports = config['forwarded_ports'] || nil
+    @forwarded_ports    = config['forwarded_ports'] || nil
+    @synced_folder_type = config['synced_folder_type'] || "nfs"
   end
 
   # Getter that first check if the accessor exists on the class and if


### PR DESCRIPTION
This feature allows to use the default synced folder implementation. Up to now, only nfs was used, which could cause a problem, depending on the environment. The implementation can be set in parameters.yml. To stay backward compatible, the default option (if not configured) is still nfs.

* This PR is a : [New feature]

- [ ] Documentation is written - no documentation about the current nfs requirements anywhere.
- [x] `parameters.yml.dist` is updated
- [ ] `playbook.yml.dist` is updated - not applicable
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
