### PR TITLE
Webpack: use absolute path for the output.path config value, fix #177

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Added
 - Virtualenv role: add `pip_requirements_dir` option to automatically compile `.in` requirements
 
+### Fixed
+- Webpack: use absolute path for the output.path config value
+
 ## [1.2.0] - 2017-03-28
 
 ### Added

--- a/provisioning/roles/gulp/templates/webpack.config.js
+++ b/provisioning/roles/gulp/templates/webpack.config.js
@@ -12,7 +12,7 @@ const webpackConfig = {
   },
   entry: './static/javascripts/index.js',
   output: {
-    path: './static/javascripts',
+    path: path.resolve(__dirname, 'static/javascripts'),
     filename: 'bundle.js'
   },
   module: {


### PR DESCRIPTION
This PR is a Bugfix for #177

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
