### PR TITLE
Add `gulp_create_config` to make gulp.config.js file creation optional, fix #114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Added
 - Virtualenv role: add `pip_requirements_dir` option to automatically compile `.in` requirements
+- Gulp: add `gulp_use_config` to make gulp.config.js file creation optional
 
 ## [1.2.0] - 2017-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Added
 - Virtualenv role: add `pip_requirements_dir` option to automatically compile `.in` requirements
-- Gulp: add `gulp_create_config` to make gulp.config.js file creation optional
+- Gulp role: add `gulp_create_config` to make gulp.config.js file creation optional
 
 ### Fixed
-- Webpack: use absolute path for the output.path config value
+- Webpack role: use absolute path for the output.path config value
 
 ## [1.2.0] - 2017-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Added
 - Virtualenv role: add `pip_requirements_dir` option to automatically compile `.in` requirements
-- Gulp: add `gulp_use_config` to make gulp.config.js file creation optional
+- Gulp: add `gulp_create_config` to make gulp.config.js file creation optional
 
 ## [1.2.0] - 2017-03-28
 

--- a/docs/roles/frontend.rst
+++ b/docs/roles/frontend.rst
@@ -33,6 +33,8 @@ Parameters
    created, defaults to ``<gulp_directory>/package.json``
 -  **gulp\_package\_json\_author**: Author that should be put in the
    package.json file, defaults to ``Liip AG``
+-  **gulp\_use\_config**: Create the gulp.config.js used by the default Gulpefile.js, defaults to
+   ``true``
 -  **gulp\_use\_webpack**: Setup Webpack alongside Gulp, defaults to
    ``true``
 -  **gulp\_use\_purescript**: Add PureScript support to Webpack,

--- a/docs/roles/frontend.rst
+++ b/docs/roles/frontend.rst
@@ -33,7 +33,7 @@ Parameters
    created, defaults to ``<gulp_directory>/package.json``
 -  **gulp\_package\_json\_author**: Author that should be put in the
    package.json file, defaults to ``Liip AG``
--  **gulp\_use\_config**: Create the gulp.config.js used by the default Gulpefile.js, defaults to
+-  **gulp\_create\_config**: Create the gulp.config.js used by the default Gulpefile.js, defaults to
    ``true``
 -  **gulp\_use\_webpack**: Setup Webpack alongside Gulp, defaults to
    ``true``

--- a/provisioning/roles/gulp/defaults/main.yml
+++ b/provisioning/roles/gulp/defaults/main.yml
@@ -1,7 +1,7 @@
 gulp_directory: /vagrant/
 gulp_package_json_path: "{{ gulp_directory }}/package.json"
 gulp_package_json_author: Liip AG
-gulp_use_config: true
+gulp_create_config: true
 gulp_use_webpack: true
 gulp_use_purescript: false
 gulp_browserslist:

--- a/provisioning/roles/gulp/defaults/main.yml
+++ b/provisioning/roles/gulp/defaults/main.yml
@@ -1,6 +1,7 @@
 gulp_directory: /vagrant/
 gulp_package_json_path: "{{ gulp_directory }}/package.json"
 gulp_package_json_author: Liip AG
+gulp_use_config: true
 gulp_use_webpack: true
 gulp_use_purescript: false
 gulp_browserslist:

--- a/provisioning/roles/gulp/tasks/main.yml
+++ b/provisioning/roles/gulp/tasks/main.yml
@@ -5,15 +5,11 @@
     - { src: Gulpfile.js, dest: "{{ gulp_directory }}/Gulpfile.js" }
 
 - name: Create Gulp config file
-  template: src={{ item.src }} dest={{ item.dest }} force=no
-  with_items:
-    - { src: gulp.config.js, dest: "{{ gulp_directory }}/gulp.config.js" }
+  template: src=gulp.config.js dest={{ gulp_directory }}/gulp.config.js force=no
   when: gulp_create_config
 
 - name: Create webpack.config.js
-  template: src={{ item.src }} dest={{ item.dest }} force=no
-  with_items:
-    - { src: webpack.config.js, dest: "{{ gulp_directory }}/webpack.config.js" }
+  template: src=webpack.config.js dest={{ gulp_directory }}/webpack.config.js force=no
   when: gulp_use_webpack
 
 - name: Install Gulp globally

--- a/provisioning/roles/gulp/tasks/main.yml
+++ b/provisioning/roles/gulp/tasks/main.yml
@@ -8,7 +8,7 @@
   template: src={{ item.src }} dest={{ item.dest }} force=no
   with_items:
     - { src: gulp.config.js, dest: "{{ gulp_directory }}/gulp.config.js" }
-  when: gulp_use_config
+  when: gulp_create_config
 
 - name: Create webpack.config.js
   template: src={{ item.src }} dest={{ item.dest }} force=no

--- a/provisioning/roles/gulp/tasks/main.yml
+++ b/provisioning/roles/gulp/tasks/main.yml
@@ -3,7 +3,12 @@
   with_items:
     - { src: package.json, dest: "{{ gulp_package_json_path }}" }
     - { src: Gulpfile.js, dest: "{{ gulp_directory }}/Gulpfile.js" }
+
+- name: Create Gulp config file
+  template: src={{ item.src }} dest={{ item.dest }} force=no
+  with_items:
     - { src: gulp.config.js, dest: "{{ gulp_directory }}/gulp.config.js" }
+  when: gulp_use_config
 
 - name: Create webpack.config.js
   template: src={{ item.src }} dest={{ item.dest }} force=no

--- a/provisioning/roles/gulp/templates/gulp.config.js
+++ b/provisioning/roles/gulp/templates/gulp.config.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   browserSync: {
     proxy:          '{{ hostname }}',
-{% if ssl %}
+{% if ssl|default(false) and ssl_key_file is defined and ssl_cert_file is defined %}
     https: {
       key: '{{ ssl_key_file }}',
       cert: '{{ ssl_cert_file }}'


### PR DESCRIPTION
* This PR is an improvement related to #114 

- [x] Documentation is written
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
