### PR TITLE
Fix Rails HTTP Scheme forwarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Fixed
 - Webpack: use absolute path for the output.path config value
+- Nginx role: add add X-Forwarded-Proto header in Rails site template
 
 ## [1.2.0] - 2017-03-28
 

--- a/provisioning/roles/nginx/templates/rails-site.j2
+++ b/provisioning/roles/nginx/templates/rails-site.j2
@@ -5,6 +5,7 @@
 
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $http_host;
         proxy_redirect off;
         proxy_pass	http://localhost:{{ proxy_port | default(3000) }};


### PR DESCRIPTION
Rails app needs the HTTP scheme forwarded from nginx proxy (to know if it's a http or https request). 

* This PR is a : Bugfix