### PR TITLE
don't download surby.org gpg key, when not needed. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations.html.
 
+## Unreleased
+
+### Fixed
+- PHP role: don't download surby.org gpg key, when not needed. Fixes problem on wheezy.
+
 ## [1.3.0] - 2017-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations.html.
 
-## Unreleased
+## [1.3.0] - 2017-04-26
 
 ### Added
 - Virtualenv role: add `pip_requirements_dir` option to automatically compile `.in` requirements
@@ -253,7 +253,8 @@ Some of the roles still survives today, so not everything was lost ;)
 ## Added
 - Roles : Apache, PHP
 
-[Unreleased]: https://github.com/liip/drifter/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/liip/drifter/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/liip/drifter/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/liip/drifter/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/liip/drifter/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/liip/drifter/compare/v1.0.9...v1.1.0

--- a/provisioning/roles/php/tasks/debian-repo.yml
+++ b/provisioning/roles/php/tasks/debian-repo.yml
@@ -13,6 +13,7 @@
 
 - name: debian-repo | Install deb.sury.org repository key
   apt_key: id=AC0E47584A7A714D url=https://packages.sury.org/php/apt.gpg state=present
+  when: "{{ php_version_installed| version_compare('7.0', '>=') }}"
   become: yes
 
 - name: debian-repo | Add deb.sury.org repository for PHP 7.x on Jessie


### PR DESCRIPTION
Fixes problem with provisioning php on wheezy.

* This PR is a : Bugfix

- [ ] Documentation is written
- [ ] `parameters.yml.dist` is updated
- [ ] `playbook.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
