### PR TITLE
Gulp: better Webpack devtool (sourcemaps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations.html.
 
+## Unreleased
+
+### Changed
+- Gulp role: Webpack now use "cheap-module-source-map" as devtool
+
 ## [1.3.0] - 2017-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations.html.
 
-## Unreleased
+## [1.3.0] - 2017-04-26
 
 ### Added
 - Virtualenv role: add `pip_requirements_dir` option to automatically compile `.in` requirements
@@ -253,7 +253,8 @@ Some of the roles still survives today, so not everything was lost ;)
 ## Added
 - Roles : Apache, PHP
 
-[Unreleased]: https://github.com/liip/drifter/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/liip/drifter/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/liip/drifter/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/liip/drifter/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/liip/drifter/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/liip/drifter/compare/v1.0.9...v1.1.0

--- a/provisioning/roles/gulp/templates/Gulpfile.js
+++ b/provisioning/roles/gulp/templates/Gulpfile.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 /*----------------------------------------*\
   DRIFTER GULPFILE
   Version 1.1.0
@@ -21,7 +22,7 @@ const stripAnsi     = require('strip-ansi');
 /**
  * Watching files for changes
  */
-gulp.task('watch', ['build'], function() {
+gulp.task('watch', ['build'], () => {
   browserSync.init(config.browserSync);
 
   gulp.watch(config.src.sass, ['sass']);
@@ -36,39 +37,39 @@ gulp.task('watch', ['build'], function() {
  * Add vendor prefixes with Autoprefixer
  * Write sourcemaps in dev mode
  */
-gulp.task('sass', function() {
+gulp.task('sass', () => {
   return gulp.src(config.src.sass)
     .pipe($.if(!config.optimize, $.sourcemaps.init()))
     .pipe(
       $.sass(config.sass)
-        .on('error', function(error) {
+        .on('error', error => {
           browserSync.sockets.emit('fullscreen:message', {
             title: 'Sass compilation error',
-            body: error.message
+            body: error.message,
           });
           $.sass.logError.apply(this, arguments);
         })
-        .on('data', function(data) {
+        .on('data', () => {
           browserSync.sockets.emit('fullscreen:message:clear');
         })
     )
     .pipe($.autoprefixer(config.autoprefixer))
     .pipe($.if(!config.optimize, $.sourcemaps.write('.')))
     .pipe(gulp.dest(config.dest.css))
-    .pipe(browserSync.stream({match: '**/*.css'}));
+    .pipe(browserSync.stream({ match: '**/*.css' }));
 });
 
 {% if gulp_use_webpack %}
 /**
  * Bundle JavaScript modules
  */
-gulp.task('webpack', function(done) {
-  webpack.run(function(error, stats) {
+gulp.task('webpack', done => {
+  webpack.run((error, stats) => {
     if (stats.hasErrors() || stats.hasWarnings()) {
       browserSync.sockets.emit('fullscreen:message', {
         title: 'WebPack compilation error',
         body: stripAnsi(stats.toString()),
-        timeout: 100000
+        timeout: 100000,
       });
       $.util.log('[webpack]', stats.toString());
     } else {
@@ -83,13 +84,13 @@ gulp.task('webpack', function(done) {
 /**
  * Optimize images
  */
-gulp.task('images', function () {
+gulp.task('images', () => {
   return gulp.src(config.src.images)
     .pipe($.imagemin({
       progressive: true,
       svgoPlugins: [{
-        removeViewBox: false
-      }]
+        removeViewBox: false,
+      }],
     }))
     .pipe(gulp.dest(config.dest.images));
 });

--- a/provisioning/roles/gulp/templates/gulp.config.js
+++ b/provisioning/roles/gulp/templates/gulp.config.js
@@ -1,33 +1,34 @@
+/* eslint-env node */
 const argv = require('yargs').argv;
 
 module.exports = {
-  optimize:         argv.production,
+  optimize: argv.production,
   src: {
-    sass:           'static/sass/**/*.scss',
-    images:         'static/images/**/*.{gif,jpg,jpeg,png,svg}',
-    javascripts:    'static/javascripts/**/*.js',
-    templates:      '**/*.html'
+    sass: 'static/sass/**/*.scss',
+    images: 'static/images/**/*.{gif,jpg,jpeg,png,svg}',
+    javascripts: 'static/javascripts/**/*.js',
+    templates: '**/*.html',
   },
   dest: {
-    css:            'static/stylesheets',
-    images:         'static/images'
+    css: 'static/stylesheets',
+    images: 'static/images',
   },
   browserSync: {
-    proxy:          '{{ hostname }}',
+    proxy: '{{ hostname }}',
 {% if ssl|default(false) and ssl_key_file is defined and ssl_cert_file is defined %}
     https: {
       key: '{{ ssl_key_file }}',
-      cert: '{{ ssl_cert_file }}'
+      cert: '{{ ssl_cert_file }}',
     },
 {% endif %}
-    open:           false,
-    notify:         false,
-    plugins:        ['bs-pretty-message']
+    open: false,
+    notify: false,
+    plugins: ['bs-pretty-message'],
   },
   sass: {
-    outputStyle:    'compressed'
+    outputStyle: 'compressed',
   },
   autoprefixer: {
-    cascade:        false
-  }
+    cascade: false,
+  },
 };

--- a/provisioning/roles/gulp/templates/webpack.config.js
+++ b/provisioning/roles/gulp/templates/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 const path    = require('path');
 const webpack = require('webpack');
 const config  = require('./gulp.config.js');
@@ -13,7 +14,7 @@ const webpackConfig = {
   entry: './static/javascripts/index.js',
   output: {
     path: path.resolve(__dirname, 'static/javascripts'),
-    filename: 'bundle.js'
+    filename: 'bundle.js',
   },
   module: {
     rules: [
@@ -26,8 +27,8 @@ const webpackConfig = {
           psc: 'psa',
           pscArgs: { sourceMaps: true },
           pscIde: true,
-          src: ['bower_components/purescript-*/src/**/*.purs', 'src/**/*.purs']
-        }
+          src: ['bower_components/purescript-*/src/**/*.purs', 'src/**/*.purs'],
+        },
       },
 {% endif %}
       {
@@ -37,30 +38,30 @@ const webpackConfig = {
         options: {
           presets: [
             ['env', {
-              'targets': {
-                'browsers': {{ gulp_browserslist | to_json }}
-              }
-            }]
-          ]
-        }
-      }
-    ]
-  }
+              targets: {
+                browsers: {{ gulp_browserslist | to_json }},
+              },
+            }],
+          ],
+        },
+      },
+    ],
+  },
 };
 
 if (config.optimize) {
   webpackConfig.plugins = [
     new webpack.DefinePlugin({
       'process.env': {
-        'NODE_ENV': JSON.stringify('production')
-      }
+        NODE_ENV: JSON.stringify('production'),
+      },
     }),
     new webpack.optimize.UglifyJsPlugin({
-      comments: false
-    })
+      comments: false,
+    }),
   ];
 } else {
-  webpackConfig.devtool = '#eval';
+  webpackConfig.devtool = 'cheap-module-source-map';
 }
 
 module.exports = webpackConfig;


### PR DESCRIPTION
According to [this evaluation](https://github.com/webpack/webpack/issues/2145#issuecomment-294361203), I decided to change the default Webpack devtool to maximize compatibility/accuracy.

I also updated the templates syntax to be more consistent.

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
