### PR TITLE
Prevent "This script is only accessible from localhost." when accessing web/app_dev.php and web/config.php for symfony2-site

### DIFF
--- a/provisioning/roles/nginx/templates/symfony2-site.j2
+++ b/provisioning/roles/nginx/templates/symfony2-site.j2
@@ -17,6 +17,7 @@
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param REMOTE_ADDR 127.0.0.1;
     }
 
     # PROD


### PR DESCRIPTION
By default, Symfony prevents accessing to `web/app_dev.php` and `web/config.php` (which is auto-generated) by adding a check on `$_SERVER['REMOTE_ADDR'] === ('127.0.0.1' || '::1')`, which fails in the vagrant box. This PR is an improvement that fixes it.