### PR TITLE
Add a template for symfony4-site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Added
 
+- Nginx role: added Symfony4 template (PR #187)
 - Disable AppArmor by default to ensure compatibility with Debian Linux Kernel 4.13
 
 ## [1.5.0] - 2017-10-30

--- a/docs/roles/webservers.rst
+++ b/docs/roles/webservers.rst
@@ -75,6 +75,7 @@ Parameters
   -  ``php-site.j2`` Site template for generic PHP
   -  ``silex-site.j2`` Site template for Silex
   -  ``symfony2-site.j2`` Site template for Symfony2
+  -  ``symfony4-site.j2`` Site template for Symfony4
 
 -  **index** : what file do we use as an index ? defaults to 'false'
 -  **static_host** : Which static host to use for Django projects ?

--- a/provisioning/roles/nginx/templates/symfony4-site.j2
+++ b/provisioning/roles/nginx/templates/symfony4-site.j2
@@ -1,0 +1,33 @@
+{% extends "nginx/templates/default-site.j2" %}
+
+{% block extra %}
+    {{ super() }}
+    # Inspired from http://symfony.com/doc/current/setup/web_server_configuration.html#nginx
+    location / {
+        # try to serve file directly, fallback to index.php
+        try_files $uri /index.php$is_args$args;
+    }
+    location ~ ^/index\.php(/|$) {
+        fastcgi_pass unix:{{ fpm_socket }};
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        # When you are using symlinks to link the document root to the
+        # current version of your application, you should pass the real
+        # application path instead of the path to the symlink to PHP
+        # FPM.
+        # Otherwise, PHP's OPcache may not properly detect changes to
+        # your PHP files (see https://github.com/zendtech/ZendOptimizerPlus/issues/126
+        # for more information).
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        # Prevents URIs that include the front controller. This will 404:
+        # http://domain.tld/index.php/some-path
+        # Remove the internal directive to allow URIs like this
+        internal;
+    }
+    # return 404 for all other php files not matching the front controller
+    # this prevents access to other php files you don't want to be accessible.
+    location ~ \.php$ {
+        return 404;
+    }
+{% endblock %}


### PR DESCRIPTION
In Symfony 4 structure, there is only a `web/index.php` front controller (no more `app.php`/`app_dev.php`). This includes the fix in https://github.com/liip/drifter/pull/186 too.