### PR TITLE
Nginx: Allow to extends templates anywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Changed
 - Gulp role: Webpack now uses "cheap-module-source-map" as devtool
+- Nginx role: Allow to extends templates from outside the templates directory
 
 ### Fixed
 - PHP role: don't download surby.org gpg key, when not needed. Fixes problem on wheezy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Changed
 - Gulp role: Webpack now uses "cheap-module-source-map" as devtool
-- Nginx role: Allow to extends templates from outside the templates directory
+- Nginx role: allow to extend templates from outside the templates directory
 
 ### Fixed
 - PHP role: don't download surby.org gpg key, when not needed. Fixes problem on wheezy

--- a/docs/roles/webservers.rst
+++ b/docs/roles/webservers.rst
@@ -27,10 +27,24 @@ roles do it automatically with the correct parameters.
 The server logs are stored in
 ``/var/log/nginx/<hostname>.(error|access).log``.
 
+You can have your own site template in your project directory,
+for example `virtualization/templates/nginx.j2` and extends one of the
+default templates provided:
+
+```
+{% extends "nginx/templates/default-site.j2" %}
+
+{% block extra %}
+    {{ super() }}
+
+    # Here goes your custom Nginx rules
+{% endblock %}
+```
+
 Parameters
 ----------
 
--  **site\_template** : The virtual host template to use, defaults to
+-  **site_template** : The virtual host template to use, defaults to
    "default-site.j2" for static websites only, possible values are:
 -  ``default-site.j2``
 -  ``django-site.j2`` Site template for Django
@@ -42,10 +56,10 @@ Parameters
 -  ``symfony2-site.j2`` Site template for Symfony2
 
 -  **index** : what file do we use as an index ? defaults to 'false'
--  **static\_host** : Which static host to use for Django projects ?
+-  **static_host** : Which static host to use for Django projects ?
    defaults to "false".
--  **static\_dir** : Which static URL dir to use for Django projects ?
+-  **static_dir** : Which static URL dir to use for Django projects ?
    defaults to "false".
--  **static\_fs\_dir** : Which static filesystem dir to use for Django
+-  **static_fs_dir** : Which static filesystem dir to use for Django
    projects ? defaults to "".
--  **expire\_time** : Expiration time of static files, defaults to "6h"
+-  **expire_time** : Expiration time of static files, defaults to "6h"

--- a/docs/roles/webservers.rst
+++ b/docs/roles/webservers.rst
@@ -28,32 +28,51 @@ The server logs are stored in
 ``/var/log/nginx/<hostname>.(error|access).log``.
 
 You can have your own site template in your project directory,
-for example `virtualization/templates/nginx.j2` and extends one of the
+for example `virtualization/templates/nginx.j2` and extend one of the
 default templates provided:
 
-```
-{% extends "nginx/templates/default-site.j2" %}
+.. code-block:: jinja
 
-{% block extra %}
-    {{ super() }}
+    {% extends "nginx/templates/default-site.j2" %}
 
-    # Here goes your custom Nginx rules
-{% endblock %}
-```
+    {% block extra %}
+        {{ super() }}
+
+        # Here goes your custom Nginx rules
+    {% endblock %}
+
+Then set the ``site_template`` parameter to ``nginx.j2`` when including the nginx role (or any other that depend
+on the nginx role):
+
+.. code-block:: yaml
+
+    roles:
+        - { role: nginx, site_template: nginx.j2 }
+
+
+If you want to use roles that include nginx, such as php-fpm, make sure you use the right parameter name (check the
+docs):
+
+.. code-block:: yaml
+
+    roles:
+        - { role: php-fpm, nginx_site_template: nginx.j2 }
+
 
 Parameters
 ----------
 
 -  **site_template** : The virtual host template to use, defaults to
    "default-site.j2" for static websites only, possible values are:
--  ``default-site.j2``
--  ``django-site.j2`` Site template for Django
--  ``drupal6-site.j2`` Site template for Drupal6
--  ``drupal7-site.j2`` Site template for Drupal7
--  ``drupal8-site.j2`` Site template for Drupal8
--  ``php-site.j2`` Site template for generic PHP
--  ``silex-site.j2`` Site template for Silex
--  ``symfony2-site.j2`` Site template for Symfony2
+
+  -  ``default-site.j2``
+  -  ``django-site.j2`` Site template for Django
+  -  ``drupal6-site.j2`` Site template for Drupal6
+  -  ``drupal7-site.j2`` Site template for Drupal7
+  -  ``drupal8-site.j2`` Site template for Drupal8
+  -  ``php-site.j2`` Site template for generic PHP
+  -  ``silex-site.j2`` Site template for Silex
+  -  ``symfony2-site.j2`` Site template for Symfony2
 
 -  **index** : what file do we use as an index ? defaults to 'false'
 -  **static_host** : Which static host to use for Django projects ?

--- a/provisioning/roles/nginx/templates/django-site.j2
+++ b/provisioning/roles/nginx/templates/django-site.j2
@@ -1,4 +1,4 @@
-{% extends "default-site.j2" %}
+{% extends "nginx/templates/default-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/drupal6-site.j2
+++ b/provisioning/roles/nginx/templates/drupal6-site.j2
@@ -1,4 +1,4 @@
-{% extends "php-site.j2" %}
+{% extends "nginx/templates/php-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/drupal7-site.j2
+++ b/provisioning/roles/nginx/templates/drupal7-site.j2
@@ -1,4 +1,4 @@
-{% extends "php-site.j2" %}
+{% extends "nginx/templates/php-site.j2" %}
 
 {% block extra %}
     {{ super() }}
@@ -33,7 +33,7 @@
         try_files $uri /index.php?$query_string;
     }
 
-     location @rewrite {
-         rewrite ^ /index.php;
-     }
+    location @rewrite {
+        rewrite ^ /index.php;
+    }
 {% endblock %}

--- a/provisioning/roles/nginx/templates/drupal8-site.j2
+++ b/provisioning/roles/nginx/templates/drupal8-site.j2
@@ -1,4 +1,4 @@
-{% extends "default-site.j2" %}
+{% extends "nginx/templates/default-site.j2" %}
 
 {% block extra %}
     {{ super() }}
@@ -33,9 +33,9 @@
         try_files $uri /index.php?$query_string;
     }
 
-     location @rewrite {
-         rewrite ^ /index.php;
-     }
+    location @rewrite {
+        rewrite ^ /index.php;
+    }
 
     # In Drupal 8, we must also match new paths where the '.php' appears in
     # the middle, such as update.php/selection. The rule we use is strict,
@@ -51,5 +51,4 @@
     location ~ '\.php$|^/update.php' {
         include conf.d/partials/_php_fpm.conf;
     }
-
 {% endblock %}

--- a/provisioning/roles/nginx/templates/php-site.j2
+++ b/provisioning/roles/nginx/templates/php-site.j2
@@ -1,4 +1,4 @@
-{% extends "default-site.j2" %}
+{% extends "nginx/templates/default-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/rails-site.j2
+++ b/provisioning/roles/nginx/templates/rails-site.j2
@@ -1,4 +1,4 @@
-{% extends "default-site.j2" %}
+{% extends "nginx/templates/default-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/silex-site.j2
+++ b/provisioning/roles/nginx/templates/silex-site.j2
@@ -1,31 +1,30 @@
-{% extends "default-site.j2" %}
+{% extends "nginx/templates/default-site.j2" %}
 
 {% block extra %}
     {{ super() }}
 
-     location / {
-             # try to serve file directly, fallback to front controller
-             try_files $uri /index.php$is_args$args;
-         }
+    location / {
+        # try to serve file directly, fallback to front controller
+        try_files $uri /index.php$is_args$args;
+    }
 
-         # If you have 2 front controllers for dev|prod use the following line instead
-         # location ~ ^/(index|index_dev)\.php(/|$) {
-         location ~ ^/index\.php(/|$) {
-             fastcgi_pass unix:{{ fpm_socket }};
-             fastcgi_split_path_info ^(.+\.php)(/.*)$;
-             include fastcgi_params;
-             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-             fastcgi_param HTTPS off;
+    # If you have 2 front controllers for dev|prod use the following line instead
+    # location ~ ^/(index|index_dev)\.php(/|$) {
+    location ~ ^/index\.php(/|$) {
+        fastcgi_pass unix:{{ fpm_socket }};
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTPS off;
 
-             # Prevents URIs that include the front controller. This will 404:
-             # http://domain.tld/index.php/some-path
-             # Enable the internal directive to disable URIs like this
-             # internal;
-         }
+        # Prevents URIs that include the front controller. This will 404:
+        # http://domain.tld/index.php/some-path
+        # Enable the internal directive to disable URIs like this
+        # internal;
+    }
 
-         #return 404 for all php files as we do have a front controller
-         location ~ \.php$ {
-             return 404;
-         }
-
+    #return 404 for all php files as we do have a front controller
+    location ~ \.php$ {
+        return 404;
+    }
 {% endblock %}

--- a/provisioning/roles/nginx/templates/symfony2-site.j2
+++ b/provisioning/roles/nginx/templates/symfony2-site.j2
@@ -1,4 +1,4 @@
-{% extends "default-site.j2" %}
+{% extends "nginx/templates/default-site.j2" %}
 
 {% block extra %}
     {{ super() }}


### PR DESCRIPTION
This allows users to create their own Nginx template in their projects *and* extend Drifter defaults. The changes in the default templates are required when the user extends a template that itself extends another (like PHP extends default). Without this the provisioning fails because it is not able to resolve the parent template.

This PR is a: Improvement

- [x] Documentation is written
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
