### PR TITLE
Mysql role: Use become to create database and user. Fix problem on xenial.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Gulp role: Webpack now uses "cheap-module-source-map" as devtool
 
 ### Fixed
+- Mysql role: use become to create database and user. Fixes problem on trusty
 - PHP role: don't download surby.org gpg key, when not needed. Fixes problem on wheezy
 
 ## [1.3.0] - 2017-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Gulp role: Webpack now uses "cheap-module-source-map" as devtool
 
 ### Fixed
-- Mysql role: use become to create database and user. Fixes problem on trusty
+- Mysql role: use become to create database and user. Fixes problem on xenial
 - PHP role: don't download surby.org gpg key, when not needed. Fixes problem on wheezy
 
 ## [1.3.0] - 2017-04-26

--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -135,7 +135,9 @@
     name: "{{ database_user }}"
     password: "{{ database_password }}"
     priv: "*.*:ALL,GRANT"
+  become: yes
 
 - name: create database
   mysql_db:
     name: "{{ database_name }}"
+  become: yes


### PR DESCRIPTION
:arrow_up: Ensure you have put a meaningful title in the box up there. :arrow_up:

This PR fixes an error when using the mysql role on xenial64-base. Using become when creating the database and database user will fix this problem. Tested on jessie64-base and xenial64-base.

* This PR is a : Bugfix

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
