### PR TITLE
(roles/mysql) Fix version compare for mysql_apt_config_check_deb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Fixed
 - PHP role: don't download surby.org gpg key, when not needed. Fixes problem on wheezy
+- MySQL role: don't install mysql upstream repository if a newer version is already installed.
 
 ## [1.3.0] - 2017-04-26
 

--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -54,10 +54,10 @@
   become: yes
 
 - name: check if mysql upstream repository is already installed
-  command: dpkg-query -W mysql-apt-config
+  command: dpkg-query -f '${Version}' -W mysql-apt-config
   register: mysql_apt_config_check_deb
   failed_when: mysql_apt_config_check_deb.rc > 1
-  changed_when: mysql_apt_config_check_deb.rc == 1 or '{{mysql_apt_config_version}}' not in mysql_apt_config_check_deb.stdout
+  changed_when: mysql_apt_config_check_deb.rc == 1 or mysql_apt_config_version | version_compare(mysql_apt_config_check_deb.stdout, ">")
   become: yes
 
 - name: ensure mysql upstream repository package is downloaded


### PR DESCRIPTION
The added `-f '${Version}'` to the `dpkg-query` command will only return
the version instead of `${name}          ${version}`.
Using version compare we can make sure it doesn't try to install the
mysql upstream repository package when a newer version is already
installed anyway.

Otherwise the following error occurs:

```
TASK [mysql : ensure mysql upstream repository is installed]
*******************
fatal: [php-7.0]: FAILED! => {"changed": false, "failed": true, "msg":
"A later version is already installed"}
```

* This PR is a : Bugfix

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
