### PR TITLE
Allow Node 8 and make it the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Added
 - Virtualbox: allow use of Virtualbox shared folders besides nfs
+- Node role: add support for version 8.x and make it the default
 
 ### Changed
 - Gulp role: Webpack now uses "cheap-module-source-map" as devtool

--- a/docs/roles/others.rst
+++ b/docs/roles/others.rst
@@ -19,8 +19,8 @@ Install NodeJS and NPM.
 Parameters
 ----------
 
--  **nodejs\_version** : The version to install, currently supports 7.x,
-   6.x, 5.x, 4.x, 0.12 and 0.10, default being 6.x.
+-  **nodejs\_version** : The version to install, currently supports 8.x,
+   7.x, 6.x, 5.x, 4.x, 0.12 and 0.10, default being 8.x.
 -  **nodejs\_distro** : Is automatically set to either 'jessie' or
    'wheezy' based on available information, you can also put an Ubuntu
    codename here.

--- a/provisioning/roles/nodejs/defaults/main.yml
+++ b/provisioning/roles/nodejs/defaults/main.yml
@@ -6,6 +6,6 @@ nodejs_distro: "{{
   'jessie'
 }}"
 nodejs_acceptable_distros: ["wheezy", "jessie", "stretch", "sid", "precise", "trusty"]
-nodejs_version: "6.x"
-nodejs_acceptable_versions: ["7.x", "6.x", "5.x", "4.x", "0.12", "0.10"]
+nodejs_version: "8.x"
+nodejs_acceptable_versions: ["8.x", "7.x", "6.x", "5.x", "4.x", "0.12", "0.10"]
 nodejs_with_yarn: false


### PR DESCRIPTION
Allow the latest version of Node to be installed and make it the default. It automatically comes with npm 5 which is much more powerful and fast than the previous version.

* This PR is a: Improvement

- [x] Documentation is written
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated