### PR TITLE
Clean up gulp role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations.html.
 
-## [1.5.0] - 2017-10-30
-
-### Added
-- Apache role: add support for the `web_directory` parameter
-- Solr role: allow to setup a Solr index/core during the provisioning
+## [Unreleased]
 
 ### Changed
 
@@ -22,6 +18,12 @@ For migration information, you can always have a look at https://liip-drifter.re
   `package.json` file
 - nodejs role: add parameter `nodejs_package_json_template` to customize the template used to create the `package.json`
   file
+
+## [1.5.0] - 2017-10-30
+
+### Added
+- Apache role: add support for the `web_directory` parameter
+- Solr role: allow to setup a Solr index/core during the provisioning
 
 ### Fixed
 - Vagrant: update ansible_local version for Vagrant 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 - Apache role: add support for the `web_directory` parameter
 
+### Changed
+
+- gulp and nodejs roles: call `npm install` on every provisioning, unless `nodejs_install_package_json` is set to
+  `false`
+- gulp role: rename parameter `gulp_package_json_path` to `nodejs_package_json_path`, and `gulp_package_json_author` to
+  `nodejs_package_json_author`
+- gulp role: add parameter `gulp_patch_package_json` to prevent the `gulp` role from interacting with the
+  `package.json` file
+- nodejs role: add parameter `nodejs_package_json_template` to customize the template used to create the `package.json`
+  file
+
 ### Fixed
 
 - Vagrant: update ansible_local version for Vagrant 2.0

--- a/ansible.cfg.dist
+++ b/ansible.cfg.dist
@@ -4,4 +4,3 @@ display_skipped_hosts = False
 
 # if you want a more human readable output of ansible commands (for debugging purposes), uncomment the following line
 # callback_plugins = virtualization/drifter/ansible-plugins/callback_plugins
-

--- a/docs/roles/frontend.rst
+++ b/docs/roles/frontend.rst
@@ -18,8 +18,7 @@ webpack.config.js, package.json) will not be overridden.*
    -  Lossless images optimization with ImageMin
 
 -  Create associated ``gulp.config.js`` and ``webpack.config.js``
--  Create the ``package.json`` containing the necessary dependencies to
-   be installed with NPM.
+-  Add the necessary dependencies to ``package.json`` (only if the file doesn't exist yet)
 
 After the first provisioning, you should edit the ``gulp.config.js`` and
 ``webpack.config.js`` to match your project structure.
@@ -28,11 +27,7 @@ Parameters
 ----------
 
 -  **gulp\_directory**: where should the gulpfile be created, defaults
-   to ``<project_dir>/``
--  **gulp\_package\_json\_path**: where should the package.json file be
-   created, defaults to ``<gulp_directory>/package.json``
--  **gulp\_package\_json\_author**: Author that should be put in the
-   package.json file, defaults to ``Liip AG``
+   to ``<root_directory>/``
 -  **gulp\_create\_config**: Create the gulp.config.js used by the default Gulpefile.js, defaults to
    ``true``
 -  **gulp\_use\_webpack**: Setup Webpack alongside Gulp, defaults to

--- a/docs/roles/others.rst
+++ b/docs/roles/others.rst
@@ -24,6 +24,14 @@ Parameters
 -  **nodejs\_distro** : Is automatically set to either 'jessie' or
    'wheezy' based on available information, you can also put an Ubuntu
    codename here.
+-  **nodejs_package_json_template**: template to use for the creation of the initial ``package.json`` file. Defaults to
+  ``package.json.j2``, or ``package.json.gulp.j2`` if you're using the gulp role. See the
+  ``provisioning/roles/nodejs/templates`` directory for the list of available templates.
+-  **nodejs_package_json_path**: where should the package.json file be
+   created, defaults to ``<root_directory>/package.json``
+-  **nodejs_package_json_author**: Author that should be put in the
+   package.json file, defaults to ``Liip AG``
+-  **nodejs_install_package_json**: Run ``npm install`` on each provisioning. Defaults to ``true``.
 
 OpenLDAP
 ========

--- a/playground/ansible.cfg
+++ b/playground/ansible.cfg
@@ -2,4 +2,3 @@
 roles_path = /drifter/roles
 display_skipped_hosts = False
 callback_plugins = /drifter_plugins/callback_plugins
-

--- a/provisioning/roles/gulp/defaults/main.yml
+++ b/provisioning/roles/gulp/defaults/main.yml
@@ -1,6 +1,5 @@
-gulp_directory: /vagrant/
+gulp_directory: "{{ root_directory }}"
 gulp_package_json_path: "{{ gulp_directory }}/package.json"
-gulp_package_json_author: Liip AG
 gulp_create_config: true
 gulp_use_webpack: true
 gulp_use_purescript: false

--- a/provisioning/roles/gulp/meta/main.yml
+++ b/provisioning/roles/gulp/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - { role: nodejs }
+  - { role: nodejs, nodejs_package_json_template: package.json.gulp.j2 }

--- a/provisioning/roles/gulp/tasks/main.yml
+++ b/provisioning/roles/gulp/tasks/main.yml
@@ -1,8 +1,5 @@
-- name: Create package.json and Gulpfile.js if non-existent
-  template: src={{ item.src }} dest={{ item.dest }} force=no
-  with_items:
-    - { src: package.json, dest: "{{ gulp_package_json_path }}" }
-    - { src: Gulpfile.js, dest: "{{ gulp_directory }}/Gulpfile.js" }
+- name: Create Gulpfile.js if non-existent
+  template: src=Gulpfile.js dest={{ gulp_directory }}/Gulpfile.js force=no
 
 - name: Create Gulp config file
   template: src=gulp.config.js dest={{ gulp_directory }}/gulp.config.js force=no
@@ -20,6 +17,3 @@
   npm: name=purescript global=yes
   become: yes
   when: gulp_use_purescript
-
-- name: Install Node modules
-  npm: path=/vagrant

--- a/provisioning/roles/nodejs/defaults/main.yml
+++ b/provisioning/roles/nodejs/defaults/main.yml
@@ -9,3 +9,7 @@ nodejs_acceptable_distros: ["wheezy", "jessie", "stretch", "sid", "precise", "tr
 nodejs_version: "8.x"
 nodejs_acceptable_versions: ["8.x", "7.x", "6.x", "5.x", "4.x", "0.12", "0.10"]
 nodejs_with_yarn: false
+nodejs_package_json_template: package.json.j2
+nodejs_package_json_path: "{{ root_directory }}/package.json"
+nodejs_package_json_author: Liip AG
+nodejs_install_package_json: true

--- a/provisioning/roles/nodejs/handlers/main.yml
+++ b/provisioning/roles/nodejs/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: install package.json
+  npm: path="{{ nodejs_package_json_path|dirname }}"

--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -32,3 +32,12 @@
   apt: pkg=yarn state=latest
   become: yes
   when: nodejs_with_yarn
+
+- name: Create default package.json
+  template: src={{ nodejs_package_json_template }} dest={{ nodejs_package_json_path }} force=no
+
+- name: Install npm packages
+  command: /bin/true
+  notify:
+    - install package.json
+  when: nodejs_install_package_json

--- a/provisioning/roles/nodejs/templates/package.json.gulp.j2
+++ b/provisioning/roles/nodejs/templates/package.json.gulp.j2
@@ -1,7 +1,7 @@
 {
   "name": "{{ project_name }}",
   "version": "1.0.0",
-  "author": "{{ gulp_package_json_author }}",
+  "author": "{{ nodejs_package_json_author }}",
   "license": "private",
   "private": true,
   "scripts": {

--- a/provisioning/roles/nodejs/templates/package.json.j2
+++ b/provisioning/roles/nodejs/templates/package.json.j2
@@ -1,0 +1,12 @@
+{
+  "name": "{{ project_name }}",
+  "version": "1.0.0",
+  "author": "{{ nodejs_package_json_author }}",
+  "license": "private",
+  "private": true,
+  "devDependencies": {
+    "browser-sync": "^2.12.7",
+    "bs-pretty-message": "^1.0.8",
+    "yargs": "^6.6.0"
+  }
+}

--- a/provisioning/roles/nodejs/templates/package.json.j2
+++ b/provisioning/roles/nodejs/templates/package.json.j2
@@ -3,10 +3,5 @@
   "version": "1.0.0",
   "author": "{{ nodejs_package_json_author }}",
   "license": "private",
-  "private": true,
-  "devDependencies": {
-    "browser-sync": "^2.12.7",
-    "bs-pretty-message": "^1.0.8",
-    "yargs": "^6.6.0"
-  }
+  "private": true
 }


### PR DESCRIPTION
Clean up the `gulp` role and `nodejs` role to put the creation of the `package.json` file in the `nodejs` role instead of the `gulp` role. The `gulp` role now only patches the existing `package.json` file. Also I think this would close https://github.com/liip/drifter/issues/161.

- [x] Documentation is written
- [x] `parameters.yml.dist` is updated
- [x] `playbook.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
