### PR TITLE
Add `version` parameters for java roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Add `firefox` role to install a specific version or the latest Firefox version
 - Add `chrome` role to install the Chrome browser
 - Add plugin to improve Ansible output readability, see `ansible.cfg.dist` for to enable it
+- Add parameters java_jre_version & java_jdk_version
 
 ### Changed
 - Gulp role: Webpack now uses "cheap-module-source-map" as devtool

--- a/docs/roles/java.rst
+++ b/docs/roles/java.rst
@@ -6,13 +6,25 @@ Java
 ====
 
 Installs a Java Runtime Environment using the OpenJDK Debian package.
-Currently installs the version 7.
+
+Parameters
+----------
+
+-  **java\_jre\_version**: JRE version to install, defaults to 7. Set
+   your version according to your needs and your Linux distribution.
+-  **java\_jre\_package**: default is "openjdk-{{ java\_jre\_version }}-jre"
 
 JDK
 ===
 
 Installs a Java Development Kit using the OpenJDK Debian package.
-Currently installs the version 7.
+
+Parameters
+----------
+
+-  **java\_jdk\_version**: JDK version to install, defaults to 7. Set
+   your version according to your needs and your Linux distribution.
+-  **java\_jdk\_package**: default is "openjdk-{{ java\_jdk\_version }}-jdk"
 
 Maven
 =====

--- a/parameters.yml.dist
+++ b/parameters.yml.dist
@@ -62,3 +62,9 @@ root_directory: "/vagrant/"
 # php7 (with fpm and nginx) anyway.
 # box_name: "drifter/trusty64-base"
 # box_url: "https://vagrantbox-public.liip.ch/drifter-trusty64-base.json"
+
+# Default Java version is 7. If you need another java version, uncomment
+# the matching line and set the correct value.
+# Set your version according to your needs and your Linux distribution.
+# java_jre_version: "7"
+# java_jdk_version: "7"

--- a/provisioning/roles/java/defaults/main.yml
+++ b/provisioning/roles/java/defaults/main.yml
@@ -1,0 +1,2 @@
+java_jre_version: "7"
+java_jre_package: "openjdk-{{ java_jre_version }}-jre"

--- a/provisioning/roles/java/tasks/main.yml
+++ b/provisioning/roles/java/tasks/main.yml
@@ -1,3 +1,3 @@
 - name: ensure Java Runtime Environment is installed
-  apt: pkg=openjdk-7-jre state=installed
+  apt: pkg={{ java_jre_package }} state=installed
   become: yes

--- a/provisioning/roles/jdk/defaults/main.yml
+++ b/provisioning/roles/jdk/defaults/main.yml
@@ -1,0 +1,2 @@
+java_jdk_version: "7"
+java_jdk_package: "openjdk-{{ java_jdk_version }}-jdk"

--- a/provisioning/roles/jdk/tasks/main.yml
+++ b/provisioning/roles/jdk/tasks/main.yml
@@ -1,3 +1,3 @@
 - name: ensure Java Development Kit (with JRE) is installed
-  apt: pkg=openjdk-7-jdk state=installed
+  apt: pkg={{ java_jdk_package }} state=installed
   become: yes


### PR DESCRIPTION
JRE or JDK version 7 is not available anymore in latest Linux distrib.

* This PR is a : Improvement

- [x] Documentation is written
- [x] `parameters.yml.dist` is updated
- [x] `playbook.yml.dist` is updated - N/A
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
