### PR TITLE
Update ansible_local version for Vagrant 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 - Apache role: add support for the `web_directory` parameter
 
+### Fixed
+
+- Vagrant: update ansible_local version for Vagrant 2.0
+
 ## [1.4.0] - 2017-09-20
 
 ### Added

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -164,7 +164,7 @@ SCRIPT
             ansible.raw_ssh_args = ['-o ControlMaster=no']
         else
             ansible.install = true
-            ansible.version = "2.1.1"
+            ansible.version = "2.1.1.0"
             ansible.install_mode = :pip
         end
     end


### PR DESCRIPTION
Vagrant version 2.0 cannot find ansible_local to install. The message from ansible is:

The requested Ansible version (2.1.1) was not found on the guest.
Please check the Ansible installation on your Vagrant guest system
(currently: 2.1.1.0),
or adapt the provisioner `version` option in your Vagrantfile.
See https://docs.vagrantup.com/v2/provisioning/ansible_common.html#version
for more information.

This was verify by downgrading and upgrading between Vagrant 2.0 and 1.9.1

* This PR is a : Bugfix

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
