### PR TITLE
Make the LXC containers run unconfined under AppArmor

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,6 +118,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         if Vagrant.has_plugin?("vagrant-hostmanager")
             override.hostmanager.ignore_private_ip = true
         end
+        # Cope with AppArmor, as it's enforced on recent Debian
+        lxc.customize 'aa_profile', 'unconfined'
     end
 
     # Set some env variables, so they can be used within the vagrant box as well


### PR DESCRIPTION
Recent Debian kernels enforce apparmor, which makes LXC look as broken.

Running the containers as unconfined is the quickfix needed to get the previous behaviour back.

* This PR is a : Improvement

- [] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
