### PR TITLE
Make VirtualBox memory and cpu configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ## [Unreleased]
 
-### Added
-
-- Add parameters memory & cpus and changed Vagrantfile and Vagrantfile.dist accordingly
-
 ### Changed
 
 - gulp and nodejs roles: call `npm install` on every provisioning, unless `nodejs_install_package_json` is set to
@@ -25,6 +21,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ### Added
 
+- Allow CPU count and memory to be configured in parameters.yml
 - Nginx role: added Symfony4 template (PR #187)
 - Disable AppArmor by default to ensure compatibility with Debian Linux Kernel 4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ## [Unreleased]
 
+### Added
+
+- Add parameters memory & cpus and changed Vagrantfile and Vagrantfile.dist accordingly
+
 ### Changed
 
 - gulp and nodejs roles: call `npm install` on every provisioning, unless `nodejs_install_package_json` is set to

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,8 +99,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
 
         v.linked_clone = true if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8')
-        v.memory = 4096
-        v.cpus = 2
+        v.memory = custom_config.get('memory', 4096)
+        v.cpus = custom_config.get('cpus', 2)
         v.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
         v.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
         # From the manual:

--- a/Vagrantfile.dist
+++ b/Vagrantfile.dist
@@ -32,6 +32,9 @@ class CustomConfig
 
   attr_accessor :forwarded_ports    # Port that need to be forwarded
   attr_accessor :synced_folder_type # Type of synced folder to use
+  
+  attr_accessor :cpus               # Virtual machine CPU's count use
+  attr_accessor :memory             # Virtual machine memory size use (in MB)
 
   # Retrieve the values of 'virtualization/parameters.yml' so that
   # they can be used by Vagrant. If you need to change those values
@@ -54,6 +57,9 @@ class CustomConfig
 
     @forwarded_ports    = config['forwarded_ports'] || nil
     @synced_folder_type = config['synced_folder_type'] || "nfs"
+
+    @memory             = config['memory']  || nil
+    @cpus               = config['cpus']    || nil
   end
 
   # Getter that first check if the accessor exists on the class and if

--- a/parameters.yml.dist
+++ b/parameters.yml.dist
@@ -15,6 +15,14 @@ forwarded_ports: {
     "3000": "3000",  # BrowserSync default port
 }
 
+# Virtual machine memory size use in MB. Defaults to 4096. Uncomment and change this
+# value to suit your needs.
+# memory: 1024
+
+# Virtual machine CPU's count use. Defaults to 2. Uncomment and change this
+# value to suit your needs.
+# cpus: 1
+
 # By default Vagrant managed different IPs for all boxes. But you can force it
 # here if you want. WARNING, this parameter will not guarantee that your box
 # will be accessible at this IP depending on your network configuration or

--- a/parameters.yml.dist
+++ b/parameters.yml.dist
@@ -17,10 +17,12 @@ forwarded_ports: {
 
 # Virtual machine memory size use in MB. Defaults to 4096. Uncomment and change this
 # value to suit your needs.
+# Note: only used with VirtualBox provider.
 # memory: 1024
 
 # Virtual machine CPU's count use. Defaults to 2. Uncomment and change this
 # value to suit your needs.
+# Note: only used with VirtualBox provider.
 # cpus: 1
 
 # By default Vagrant managed different IPs for all boxes. But you can force it


### PR DESCRIPTION
Hi !
I'm completely new to Vagrant and I discovered drifter from a friend of mine. I was surprised when I did not find a way in the files (Vagrantfile or parameters.yml) to set the memory and cpus like other parameters. So I made them available as parameters and default the values in case the parameters were not set. I hope this helps.

* This PR is a : Improvement

- [x] ~~Documentation is written~~
- [x] `parameters.yml.dist` is updated
- [x] ~~`playbook.yml.dist` is updated~~
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
