### PR TITLE
Make python-apt installed status detection future-proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Nginx role: added Symfony4 template (PR #187)
 - Disable AppArmor by default to ensure compatibility with Debian Linux Kernel 4.13
 
+### Fixed
+
+- Make python-apt installed status detection future-proof (PR #204)
+
 ## [1.5.0] - 2017-10-30
 
 ### Added

--- a/provisioning/roles/base/tasks/main.yml
+++ b/provisioning/roles/base/tasks/main.yml
@@ -1,6 +1,6 @@
 # python-apt is needed for the Ansible 'apt' module, used later in this file.
 - name: ensure python-apt is installed
-  command: apt-get install -y python-apt creates=/usr/share/pyshared/apt
+  command: apt-get install -y python-apt creates=/usr/share/doc/python-apt/changelog.gz
   become: yes
 
 - name: ensure apt database is up-to-date (cache time 1h)


### PR DESCRIPTION
* This PR is a Bugfix/Improvement

On Debian Stretch+, `/usr/share/pyshared/apt` is not installed when installing `python-apt`. On the other hand, on any Debian-derivative of almost any age, `/usr/share/doc/${package}/changelog.gz` would be installed. This PR makes `drifter` more future-proof.

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
