### PR TITLE
Update rbenv, ruby-build and bump ruby default to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ virtualization/drifter/ansible.cfg.dist ansible.cfg`.
   file
 - Fix Ansible error "failed to set permissions on the temporary files". This needs updating your `ansible.cfg` file
   with the contents from `ansible.cfg.dist`
+- Ruby role: update rbenv to v1.1.1 and ruby-build to v20180224
 
 ### Added
 

--- a/docs/roles/ruby.rst
+++ b/docs/roles/ruby.rst
@@ -14,7 +14,7 @@ Parameters
 
 -  **ruby\_version**: this should be the exact version name (such as
    2.3.3). Find a list of accepted version with ``rbenv install -l``.
-   Default is 2.4.0
+   Default is 2.4.1
 
 Rails
 =====

--- a/provisioning/roles/ruby/defaults/main.yml
+++ b/provisioning/roles/ruby/defaults/main.yml
@@ -1,1 +1,1 @@
-ruby_version: 2.4.0
+ruby_version: 2.4.1

--- a/provisioning/roles/ruby/tasks/main.yml
+++ b/provisioning/roles/ruby/tasks/main.yml
@@ -10,7 +10,7 @@
   git:
     repo: https://github.com/rbenv/rbenv.git
     dest: ~/.rbenv
-    version: v1.1.0
+    version: v1.1.1
 
 - name: try to compile dynamic bash extension to speed up rbenv
   command: src/configure && make -C src
@@ -23,7 +23,7 @@
   git:
     repo: https://github.com/rbenv/ruby-build.git
     dest: ~/.rbenv/plugins/ruby-build
-    version: v20170112
+    version: v20180224
 
 - name: ensure rbenv is accessible
   lineinfile:


### PR DESCRIPTION
In a effort to stay up-to-date, I updated the ruby default version from 2.4.0 to 2.4.1 which has been released almost a year ago now. This required to update rbenv and ruby-build to have this version available in the index.

Tested in an existing ruby project, update passed successfully.