### PR TITLE
Set default backingstore to "dir" for vagrant-lxc provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ virtualization/drifter/ansible.cfg.dist ansible.cfg`.
   file
 - Fix Ansible error "failed to set permissions on the temporary files". This needs updating your `ansible.cfg` file
   with the contents from `ansible.cfg.dist`
+- Fix default backingstore to `dir` with vagrant-lxc provider
 
 ### Added
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -120,6 +120,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
         # Cope with AppArmor, as it's enforced on recent Debian
         lxc.customize 'aa_profile', 'unconfined'
+        lxc.backingstore = custom_config.get('backingstore', 'dir')
     end
 
     # Set some env variables, so they can be used within the vagrant box as well

--- a/parameters.yml.dist
+++ b/parameters.yml.dist
@@ -15,8 +15,13 @@ forwarded_ports: {
     "3000": "3000",  # BrowserSync default port
 }
 
-# Virtual machine memory size use in MB. Defaults to 4096. Uncomment and change this
+# Backingstore used by LXC. Defaults to dir. Uncomment and change this
 # value to suit your needs.
+# Note: only used with vagrant-lxc provider.
+# backingstore: dir
+
+# Virtual machine memory size use in MB. Defaults to 4096. Uncomment and change
+# this value to suit your needs.
 # Note: only used with VirtualBox provider.
 # memory: 1024
 


### PR DESCRIPTION
Ensure you have put a meaningful title in the box up there. :white_check_mark:

Vagrant-lxc provider in version 1.4.0 let you choose a backingstore other than 'dir' for LXC. The default value is 'best' and on Ubuntu Artful (maybe others) and another backingstore is chosen. This merge request is about fixing the backingstore value to 'dir' by default and make it configurable.

* This PR is a : New Feature
* Link to the related issue if relevant

- [] Documentation is written
- [x] `parameters.yml.dist` is updated
- [] `playbook.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
