### PR TITLE
Avoid re-compiling requirements files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Changed
 
 - gitlab.liip.ch got a new ssh key.
+- Avoid compiling requirements files that are already compiled in the virtualenv role
 
 ## [1.6.0] - 2018-03-27
 

--- a/provisioning/roles/virtualenv/tasks/main.yml
+++ b/provisioning/roles/virtualenv/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: list uncompiled requirements files
+  # Pipe everything to cat to avoid error in case of empty return
   shell: |
     for f in {{ root_directory }}/{{ pip_requirements_dir }}/*.in; do
       [ ! -e "${f%in}txt" ] && echo $f
-    done
-  ignore_errors: True
+    done | cat
   register: pip_requirements_files
   when: pip_requirements_dir is defined
 

--- a/provisioning/roles/virtualenv/tasks/main.yml
+++ b/provisioning/roles/virtualenv/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
-- shell: "ls {{ root_directory }}/{{ pip_requirements_dir }}/*.in"
+- name: list uncompiled requirements files
+  shell: |
+    for f in {{ root_directory }}/{{ pip_requirements_dir }}/*.in; do
+      [ ! -e "${f%in}txt" ] && echo $f
+    done
+  ignore_errors: True
   register: pip_requirements_files
   when: pip_requirements_dir is defined
 


### PR DESCRIPTION
In the virtualenv role, the pip-compile task used to compile all requirements files.
When requirements files are already compiled, we don't want this to happen.
