### PR TITLE
Add postgresql-contgrib to postgresql role

### DIFF
--- a/provisioning/roles/postgresql/tasks/main.yml
+++ b/provisioning/roles/postgresql/tasks/main.yml
@@ -19,6 +19,10 @@
   apt: pkg=libpq-dev state=latest
   become: yes
 
+- name: install postgresql extensions
+  apt: pkg=postgresql-contrib state=latest update_cache=yes
+  become: yes
+
 - name: ensure postgresql is started
   action: service name=postgresql state=started
   become: yes


### PR DESCRIPTION
Useful for exemple to use case insensitive unique index in Django.

* This PR is a : Improvement

- [ ] Documentation is written
- [ ] `parameters.yml.dist` is updated
- [ ] `playbook.yml.dist` is updated
- [ ] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
