### PR TITLE
Introduce dedicated webpack role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 - gitlab.liip.ch got a new ssh key.
 
+### Added
+
+- Webpack role: a brand new way of handling front-end assets in your projects, preconfigured!
+
 ## [1.6.0] - 2018-03-27
 
 ### Upgrade instructions

--- a/docs/roles/compass.rst
+++ b/docs/roles/compass.rst
@@ -1,0 +1,8 @@
+*******
+Compass
+*******
+
+**This role is deprecated, just as Compass is no longer supported.**
+
+Install Compass and incidentally Sass via ``apt-get``. The Ruby role is
+installed as dependency.

--- a/docs/roles/gulp.rst
+++ b/docs/roles/gulp.rst
@@ -1,9 +1,6 @@
-**************
-Frontend Roles
-**************
-
-Gulp
-====
+*********
+Gulp Role
+*********
 
 *Existing configuration files (Gulpfile.js, gulp.config.js,
 webpack.config.js, package.json) will not be overridden.*
@@ -74,11 +71,3 @@ Optimize jp(e)g, png, gif & svg files with:
 ::
 
     gulp images
-
-Compass
-=======
-
-**This role is deprecated, just as Compass is no longer supported.**
-
-Install Compass and incidentally Sass via ``apt-get``. The Ruby role is
-installed as dependency.

--- a/docs/roles/webpack.rst
+++ b/docs/roles/webpack.rst
@@ -1,0 +1,98 @@
+*******
+Webpack
+*******
+
+**Current Webpack version: 4.5.0**
+
+This role provide a pretty simple setup to handle assets (javascripts, stylesheets, images, fonts and SVG icons) through `Webpack <https://webpack.js.org/>`_ in your project.
+
+It creates a `webpack.config.js` that is preconfigured to handle:
+
+- `Sass <https://sass-lang.com/>`_ files to create stylesheets. Stylesheets are processed through `Autoprefixer <https://github.com/postcss/autoprefixer>`_ for browser compatibility and `CSSNano <http://cssnano.co/>`_ for optimisations.
+- JavaScript files through `Babel <https://babeljs.io/>`_ with babel-preset-env to use next generation JavaScript today
+- SVG icons through `svg-sprite-loader <https://github.com/kisenka/svg-sprite-loader>`_ and make a single sprite file out of it
+- Images (svg, png, jp(e)g, gif, webp)
+- Fonts (woff, woff2, eot, ttf, otf)
+
+
+Installation
+------------
+
+Once enabled, this role will create a ``webpack.config.js`` and a ``package.json`` that includes all the required dependencies by default.
+
+**Existing files (webpack.config.js, package.json) will not be overridden. If those files already exists, the installation will be incomplete and could not work as expected.**
+
+Parameters
+~~~~~~~~~~
+
+- **webpack_directory**: where should the webpack.config.js be created, defaults to ``{{ root_directory }}/``
+- **webpack_package_json_path**: where should the package.json be created, defaults to ``{{ webpack_directory }}/package.json``
+- **webpack_create_config**: Create the webpack.config.js, defaults to ``true``
+- **webpack_browserslist**: Define `Browserslist <https://github.com/ai/browserslist>`__ in ``package.json``, defaults to:
+
+    .. code-block:: yaml
+
+        - "> 0.5%"
+        - "not op_mini all"
+
+Post-install
+~~~~~~~~~~~~
+
+The default configuration expect a couple of things:
+
+- The main JavaScript file to live at ``assets/scripts/common.js`` (not created by the role)
+- All the assets to live in ``assets/…`` or in ``node_modules``
+- The SVG icons to be included in the sprite to live in ``assets/icons/``
+
+Other defaults:
+
+- Built files are bundled into the ``dist/`` folder
+- Generated icons sprite is named ``icons.svg``
+
+You can change all these default values by editing the ``webpack.config.js`` file. If you need help, you should check out the `Webpack config documentation <https://webpack.js.org/configuration/>`_.
+
+
+Default tasks
+-------------
+
+Development
+~~~~~~~~~~~
+
+::
+
+    npm start
+
+Starts ``webpack-dev-server`` at `example.lo:3000 <http://example.lo:3000>`_, compile on-the-fly and reload the browser automatically. All requests not handled by webpack will be proxified to example.lo.
+
+*Replace example.lo by the "hostname" you set in the "parameters.yml".*
+
+Notice that webpack-dev-server does not write the files to the disk. To debug which files are being served, go to `example.lo:3000/webpack-dev-server <http://example.lo:3000/webpack-dev-server>`_.
+
+Production
+~~~~~~~~~~
+
+::
+
+    npm run build
+
+Will bundle all the assets, optimized for production, in the ``dist`` folder by default.
+
+
+Loading assets
+--------------
+
+The default public path for bundled assets is ``/``.
+
+To load the main JavaScript file, use:
+
+.. code-block:: html
+
+    <script type="text/javascript" src="common.js"></script>
+
+In development, CSS is automatically injected in a ``<style>`` tag by the JavaScript file that imported it. In production, you need to include the extracted file. For example, all the CSS required by the ``common`` bundle, would be extracted as ``common.css`` and should be loaded like this:
+
+.. code-block:: html
+
+    <link rel="stylesheet" type="text/css" href="common.css">
+
+If you need help to import files such as CSS, images or fonts, take a look to the `Webpack asset management guide <https://webpack.js.org/guides/asset-management/>`_.

--- a/playground/playbook.yml
+++ b/playground/playbook.yml
@@ -27,13 +27,13 @@
     # - { role: php-apache }    # PHP using Apache and mod-php
     # - { role: django }        # Django framework
 
-    ## Webserver, choose one of those only if you have not choosed a scripting language
+    ## Webserver, choose one of those only if you have not chosen a scripting language
     ## above
     # - { role: nginx }          # Nginx for basic HTML website
     # - { role: apache }         # Apache for basic HTML website
 
-    ## Install Gulp with Drifter Gulpfile in the box
-    # - { role: gulp }
+    ## Install Webpack in the box
+    # - { role: webpack }
 
     ## Install Solr in the box
     # - { role: solr }
@@ -43,6 +43,9 @@
 
     ## Install Composer in the box
     # - { role: composer }
+
+    ## Install OpenLDAP's slapd in the box
+    # - { role: openldap }
 
     # If you want php xdebug in your local boxes, uncomment this
     # The when clause prevents it to be installed on the CI_SERVER
@@ -54,6 +57,11 @@
     ## Install some Gitlab CI scripts and .gitlab-ci.yml.
     ## See https://github.com/liip/drifter/blob/master/ci/README.md for details
     # - { role: gitlabci }
+
+    # Install Browsers for end-to-end tests
+    # - { role: firefox }
+    # - { role: chrome }
+    # - { role: phantomjs }
 
     ## You can also creates your own role, just add a directory under the 'virtualization'
     ## folder and refer to it like for other roles :

--- a/provisioning/playbook.yml.dist
+++ b/provisioning/playbook.yml.dist
@@ -32,8 +32,8 @@
     # - { role: nginx }          # Nginx for basic HTML website
     # - { role: apache }         # Apache for basic HTML website
 
-    ## Install Gulp with Drifter Gulpfile in the box
-    # - { role: gulp }
+    ## Install Webpack in the box
+    # - { role: webpack }
 
     ## Install Solr in the box
     # - { role: solr }

--- a/provisioning/roles/nodejs/templates/package.json.webpack.j2
+++ b/provisioning/roles/nodejs/templates/package.json.webpack.j2
@@ -1,0 +1,34 @@
+{
+  "name": "{{ project_name }}",
+  "version": "1.0.0",
+  "author": "{{ nodejs_package_json_author }}",
+  "license": "private",
+  "private": true,
+  "scripts": {
+    "start": "NODE_ENV=development webpack-dev-server --hot",
+    "build": "NODE_ENV=production webpack"
+  },
+  "devDependencies": {
+    "autoprefixer": "^8.2.0",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.4",
+    "babel-preset-env": "^1.6.1",
+    "css-loader": "^0.28.11",
+    "cssnano": "^3.10.0",
+    "file-loader": "^1.1.11",
+    "mini-css-extract-plugin": "^0.4.0",
+    "node-sass": "^4.8.3",
+    "postcss": "^6.0.21",
+    "postcss-cli": "^5.0.0",
+    "postcss-loader": "^2.1.3",
+    "sass-loader": "^6.0.7",
+    "style-loader": "^0.20.3",
+    "svg-sprite-loader": "^3.7.3",
+    "svgo": "^1.0.5",
+    "svgo-loader": "^2.1.0",
+    "webpack": "^4.5.0",
+    "webpack-cli": "^2.0.14",
+    "webpack-dev-server": "^3.1.3"
+  },
+  "browserslist": {{ webpack_browserslist | to_json }}
+}

--- a/provisioning/roles/webpack/defaults/main.yml
+++ b/provisioning/roles/webpack/defaults/main.yml
@@ -1,0 +1,6 @@
+webpack_directory: "{{ root_directory }}"
+webpack_package_json_path: "{{ webpack_directory }}/package.json"
+webpack_create_config: true
+webpack_browserslist:
+  - "> 0.5%"
+  - "not op_mini all"

--- a/provisioning/roles/webpack/meta/main.yml
+++ b/provisioning/roles/webpack/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: nodejs, nodejs_package_json_template: package.json.webpack.j2 }

--- a/provisioning/roles/webpack/tasks/main.yml
+++ b/provisioning/roles/webpack/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Create webpack.config.js file if non-existent
+  template: src=webpack.config.js dest={{ webpack_directory }}/webpack.config.js force=no
+  when: webpack_create_config

--- a/provisioning/roles/webpack/templates/webpack.config.js
+++ b/provisioning/roles/webpack/templates/webpack.config.js
@@ -1,0 +1,125 @@
+/* eslint-env node */
+const path = require('path');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const SpriteLoaderPlugin = require('svg-sprite-loader/plugin');
+const browserslist = require('./package.json').browserslist;
+
+module.exports = {
+  mode: process.env.NODE_ENV,
+  resolve: {
+    modules: [
+      path.resolve(__dirname, 'assets/scripts'),
+      path.resolve(__dirname, 'assets'),
+      'node_modules',
+    ],
+    extensions: ['.js'],
+  },
+  entry: {
+    common: path.resolve(__dirname, 'assets/scripts/common.js'),
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: '[name].js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        options: {
+          presets: [
+            ['env', {
+              targets: {
+                browsers: browserslist,
+              },
+            }],
+          ],
+        },
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          {
+            loader: process.env.NODE_ENV === 'production' ? MiniCssExtractPlugin.loader : 'style-loader',
+          },
+          'css-loader',
+          {
+            loader: 'postcss-loader',
+            options: {
+              plugins: [
+                require('autoprefixer')(),
+                require('cssnano')(),
+              ],
+            },
+          },
+          'sass-loader',
+        ],
+      },
+      {
+        test: /\.(svg|png|jpe?g|gif|webp|woff|woff2|eot|ttf|otf)$/,
+        exclude: path.resolve('./assets/icons'),
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name].[ext]',
+              outputPath: 'assets/',
+            },
+          },
+        ],
+      },
+      {
+        test: /\.svg$/,
+        include: path.resolve('./assets/icons'),
+        use: [
+          {
+            loader: 'svg-sprite-loader',
+            options: {
+              extract: true,
+              spriteFilename: 'icons.svg',
+              esModule: false,
+            },
+          },
+          'svgo-loader',
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: '[name].css',
+    }),
+    new SpriteLoaderPlugin(),
+  ],
+  devServer: {
+    proxy: {
+      '**': 'http://{{ hostname }}',
+    },
+    public: '{{ hostname }}:3000',
+    host: '0.0.0.0',
+    port: 3000,
+    compress: true,
+    // Polling is required inside Vagrant boxes
+    watchOptions: {
+      poll: true,
+    },
+    overlay: true,
+    // Here you can specify folders that contain your views
+    // So they’ll trigger a page reload when you change them
+    // contentBase: ['./app/views'],
+    // watchContentBase: true,
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        styles: {
+          name: 'styles',
+          test: /\.css$/,
+          chunks: 'all',
+          enforce: true,
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
I guess it deserve its own role, with webpack-dev-server in development and everything setup to completely replace Gulp. Also less hacky than the Gulp way and updated to the latest version.

- [x] Documentation is written
- [ ] ~`parameters.yml.dist` is updated~
- [x] `playbook.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
