### PR TITLE
Conditionally create package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Added option to enable assert exceptions for PHP 7.0 and above
 - Make ansible version in the guest configurable via parameters.yml
 - Django role: download and enable bash completion for django commands
+- Node.js role: allow to disable package.json creation with new parameter `nodejs_create_package_json`
 
 ### Changed
 

--- a/docs/roles/others.rst
+++ b/docs/roles/others.rst
@@ -24,6 +24,8 @@ Parameters
 -  **nodejs\_distro** : Is automatically set to either 'jessie' or
    'wheezy' based on available information, you can also put an Ubuntu
    codename here.
+-  **nodejs_create_package_json**: create a ``package.json`` file based on the
+   settings below during provisioning. Defaults to ``true``.
 -  **nodejs_package_json_template**: template to use for the creation of the initial ``package.json`` file. Defaults to
   ``package.json.j2``, or ``package.json.gulp.j2`` if you're using the gulp role. See the
   ``provisioning/roles/nodejs/templates`` directory for the list of available templates.

--- a/provisioning/roles/nodejs/defaults/main.yml
+++ b/provisioning/roles/nodejs/defaults/main.yml
@@ -12,4 +12,5 @@ nodejs_with_yarn: false
 nodejs_package_json_template: package.json.j2
 nodejs_package_json_path: "{{ root_directory }}/package.json"
 nodejs_package_json_author: Liip AG
+nodejs_create_package_json: true
 nodejs_install_package_json: true

--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -35,6 +35,7 @@
 
 - name: Create default package.json
   template: src={{ nodejs_package_json_template }} dest={{ nodejs_package_json_path }} force=no
+  when: nodejs_install_package_json
 
 - name: Install npm packages
   command: /bin/true

--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Create default package.json
   template: src={{ nodejs_package_json_template }} dest={{ nodejs_package_json_path }} force=no
-  when: nodejs_install_package_json
+  when: nodejs_create_package_json
 
 - name: Install npm packages
   command: /bin/true


### PR DESCRIPTION
Node.js tasks can be useful for projects that don't necesserally wish to expose a package.json file (like a theme inside a Drupal project), the package.json is installed based `nodejs_install_package_json`  but the package.json file is created unconditionally. The quick PR just propose to submit the `Create default package.json` task to `nodejs_install_package_json` also.

This PR is a : Improvement
