### PR TITLE
Stretch64: ensure apt database can be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Changed
 
 - gitlab.liip.ch got a new ssh key.
+- Fixed early box setup to ensure that the apt database can be queried
 
 ## [1.6.0] - 2018-03-27
 

--- a/provisioning/roles/base/tasks/main.yml
+++ b/provisioning/roles/base/tasks/main.yml
@@ -3,6 +3,16 @@
   command: apt-get install -y python-apt creates=/usr/share/doc/python-apt/changelog.gz
   become: yes
 
+- name: ensure apt database can be used
+  file:
+    name: "{{ item }}"
+    state: directory
+    recurse: true
+  with_items:
+  - /var/lib/apt/lists/
+  - /var/cache/apt/archives/
+  become: yes
+
 - name: ensure apt database is up-to-date (cache time 1h)
   apt:
     update_cache: yes


### PR DESCRIPTION
I didn't manage to fix the Stretch64-lxc image for the "Failed to lock apt for exclusive operation" error.; one way I've found is to unbreak it upon provisioning, by making sure the needed directories are present.

* This PR is a : Improvement

- [x] Documentation is written
- [x] `parameters.yml.dist` is updated
- [x] `playbook.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
