### PR TITLE
Add an option to build python from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Make ansible version in the guest configurable via parameters.yml
 - Django role: download and enable bash completion for django commands
 - Node.js role: allow to disable package.json creation with new parameter `nodejs_create_package_json`
+- Python role: add the option to build Python from source
 
 ### Changed
 

--- a/docs/roles/python.rst
+++ b/docs/roles/python.rst
@@ -18,7 +18,7 @@ Parameters
 -  **python_version**: version of Python to use. Can be 2 or 3, defaults to "3"
 -  **pip_version** : the version of pip to install in the virtual environment. Defaults to 9.0.1.
 -  **setuptools_version** : the version of setuptools to install in the virtual environment. Defaults to 28.8.0.
--  **python3_install_from_source**: false (default) or true
+-  **python3_install_from_source**: whether to install Python from source (true) or use the distribution version (false). Defaults to false
 -  **python3_source_version**: Python version like 3.5.5, defaults to "3.6.5"
 
 .. _virtualenv-reference-label:

--- a/docs/roles/python.rst
+++ b/docs/roles/python.rst
@@ -18,6 +18,8 @@ Parameters
 -  **python_version**: version of Python to use. Can be 2 or 3, defaults to "3"
 -  **pip_version** : the version of pip to install in the virtual environment. Defaults to 9.0.1.
 -  **setuptools_version** : the version of setuptools to install in the virtual environment. Defaults to 28.8.0.
+-  **python3_install_from_source**: false (default) or true
+-  **python3_source_version**: Python version like 3.5.5, defaults to "3.6.5"
 
 .. _virtualenv-reference-label:
 

--- a/provisioning/roles/python/defaults/main.yml
+++ b/provisioning/roles/python/defaults/main.yml
@@ -1,3 +1,5 @@
 python_version: "3"
 pip_version: 10.0.1
 setuptools_version: 39.1.0
+python3_install_from_source: false
+python3_source_version: "3.6.5"

--- a/provisioning/roles/python/defaults/main.yml
+++ b/provisioning/roles/python/defaults/main.yml
@@ -2,4 +2,4 @@ python_version: "3"
 pip_version: 10.0.1
 setuptools_version: 39.1.0
 python3_install_from_source: false
-python3_source_version: "3.6.5"
+python3_source_version: "3.7.2"

--- a/provisioning/roles/python/tasks/install-from-source.yml
+++ b/provisioning/roles/python/tasks/install-from-source.yml
@@ -1,0 +1,26 @@
+---
+- name: Download Python
+  get_url:
+    url: "https://www.python.org/ftp/python/{{ python3_source_version }}/Python-{{ python3_source_version }}.tgz"
+    dest: "/tmp/Python-{{ python3_source_version }}.tgz"
+
+- name: Expand Python archive
+  unarchive:
+    src: "/tmp/Python-{{ python3_source_version }}.tgz"
+    dest: "/tmp"
+    creates: "/tmp/Python-{{ python3_source_version }}/README.rst"
+    copy: no
+
+- name: Configure Python build
+  command: >
+    ./configure --with-ensurepip=install --prefix=/usr
+    chdir=/tmp/Python-{{ python3_source_version }}
+
+- name: Build Python
+  command: >
+    make {{ item }}
+    chdir=/tmp/Python-{{ python3_source_version }}
+  with_items:
+    - all
+    - install
+  become: yes

--- a/provisioning/roles/python/tasks/main.yml
+++ b/provisioning/roles/python/tasks/main.yml
@@ -19,7 +19,7 @@
   with_items:
     - python3-pip
     - python3-all-dev
-  when: ansible_lsb.major_release|int >= 8
+  when: ansible_lsb.major_release|int >= 8 and python3_install_from_source == false
 
 # The Python 3 virtualenv package is named "python3.4-venv" on Ubuntu before
 # Xenial

--- a/provisioning/roles/python/tasks/main.yml
+++ b/provisioning/roles/python/tasks/main.yml
@@ -43,3 +43,7 @@
 - name: install libjpeg-dev
   apt: pkg="{{ 'libjpeg8-dev' if (ansible_lsb.major_release|int == 7) else 'libjpeg-dev' }}" state=latest
   become: yes
+
+# Install python from source when python_install_from_source is true.
+- include: install-from-source.yml
+  when: python3_install_from_source == true and python3_source_version|version_compare('3', '>=')

--- a/provisioning/roles/python/tasks/main.yml
+++ b/provisioning/roles/python/tasks/main.yml
@@ -19,7 +19,7 @@
   with_items:
     - python3-pip
     - python3-all-dev
-  when: ansible_lsb.major_release|int >= 8 and python3_install_from_source == false
+  when: ansible_lsb.major_release|int >= 8 and not python3_install_from_source
 
 # The Python 3 virtualenv package is named "python3.4-venv" on Ubuntu before
 # Xenial
@@ -46,4 +46,4 @@
 
 # Install python from source when python_install_from_source is true.
 - include: install-from-source.yml
-  when: python3_install_from_source == true and python3_source_version|version_compare('3', '>=')
+  when: python3_install_from_source and python3_source_version|version_compare('3', '>=')


### PR DESCRIPTION
When willing to use the latest version of python, the only solution is to build it from sources as the distro packages aren't always the latest. This adds an option to do so.

* This PR is a : New feature

- [x] Documentation is written
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
