### PR TITLE
Upgrade pip-tools to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Django role: drop support for Django 1.6 and remove `django_version` parameter
 - Python role: upgrade pip to 10.0.1 and setuptools to 39.1.0
 - Python role: use Python 3 by default
+- virtualenv role: upgrade pip-tools to 2.0.1
 
 ## [1.6.0] - 2018-03-27
 

--- a/provisioning/roles/virtualenv/defaults/main.yml
+++ b/provisioning/roles/virtualenv/defaults/main.yml
@@ -1,3 +1,3 @@
 pip_requirements: requirements/dev.txt
-pip_tools_version: 1.8.2
+pip_tools_version: 2.0.1
 env_root: "~/ENV"


### PR DESCRIPTION
After upgrading pip to 10 (https://github.com/liip/drifter/commit/40c21cd0e34811822668d88024633942df71d35a), pip-compile is broken.

```
TASK [virtualenv : compile requirements files] *********************************
failed: [default] (item=/vagrant//requirements/base.in) => {"changed": true, "cmd": ["~/ENV/bin/pip-compile", "/vagrant//requirements/base.in"], "delta": "0:00:00.037165", "end": "2018-05-11 03:01:21.640613", "failed": true, "item": "/vagrant//requirements/base.in", "rc": 1, "start": "2018-05-11 03:01:21.603448", "stderr": "Traceback (most recent call last):\n  File \"/home/vagrant/ENV/bin/pip-compile\", line 7, in <module>\n    from piptools.scripts.compile import cli\n  File \"/home/vagrant/ENV/lib/python3.4/site-packages/piptools/scripts/compile.py\", line 12, in <module>\n    from pip.req import InstallRequirement, parse_requirements\nImportError: No module named 'pip.req'", "stdout": "", "stdout_lines": [], "warnings": []}
```
More info: https://stackoverflow.com/questions/25192794/no-module-named-pip-req
Therefore, upgrading pip-tools in the virtualenv role is required too.

* This PR is a : Bugfix

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
#218 