### PR TITLE
Upgrade pip-tools to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Django role: drop support for Django 1.6 and remove `django_version` parameter
 - Python role: upgrade pip to 10.0.1 and setuptools to 39.1.0
 - Python role: use Python 3 by default
+- virtualenv role: upgrade pip-tools to 2.0.1
 
 ## [1.6.0] - 2018-03-27
 

--- a/provisioning/roles/virtualenv/defaults/main.yml
+++ b/provisioning/roles/virtualenv/defaults/main.yml
@@ -1,3 +1,3 @@
 pip_requirements: requirements/dev.txt
-pip_tools_version: 1.8.2
+pip_tools_version: 2.0.1
 env_root: "~/ENV"


### PR DESCRIPTION
After upgrading pip to 10 (https://github.com/liip/drifter/commit/40c21cd0e34811822668d88024633942df71d35a), pip-compile is broken.
Therefore, upgrading pip-tools in the virtualenv role is required too.

* This PR is a : Bugfix
* #218 

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated