### PR TITLE
put a extra_server block on top in nginx/default-site.j2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 - Add [Pipenv](https://docs.pipenv.org/) role
 - Django role: add `django_use_pipenv` parameter to use Pipenv
+- Add `extra_server_top` block to `provisioning/roles/nginx/templates/default-site.j2`
 
 ### Changed
 

--- a/provisioning/roles/nginx/templates/default-site.j2
+++ b/provisioning/roles/nginx/templates/default-site.j2
@@ -1,3 +1,6 @@
+{% block extra_server_top %}
+{% endblock %}
+
 server {
     listen {{ port }};
     server_name {{ hostname }} {% for hostname in hostnames %}{{ hostname }} {% endfor %};


### PR DESCRIPTION
We need to have an extra server block before the standard server block, so that it takes precedence for some defined hosts.

* This PR is a : Improvement
* Link to the related issue if relevant

- [ ] Documentation is written
- [ ] `parameters.yml.dist` is updated
- [ ] `playbook.yml.dist` is updated
- [X] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
