### PR TITLE
Add Django bash completion in Django role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Added PHP [PhIVE](https://phar.io/) support
 - Added option to enable assert exceptions for PHP 7.0 and above
 - Make ansible version in the guest configurable via parameters.yml
+- Django role: download and enable bash completion for django commands
 
 ### Changed
 

--- a/provisioning/roles/django/tasks/main.yml
+++ b/provisioning/roles/django/tasks/main.yml
@@ -28,3 +28,11 @@
 - name: migrate
   command: "pipenv run {{ django_root }}/manage.py migrate --noinput"
   when: database_type is defined and django_use_pipenv
+
+- name: download Django bash completion file
+  get_url:
+    url: https://raw.githubusercontent.com/django/django/master/extras/django_bash_completion
+    dest: ~/.django_bash_completion
+
+- name: enable Django bash completion
+  lineinfile: dest=~/.bashrc line='. ~/.django_bash_completion'


### PR DESCRIPTION
Request from @hugo-torres who would like to get bash completion for Django command lines as this is provided by Django.

* This PR is a : Improvement

- [ ] Documentation is written: not relevant
- [ ] `parameters.yml.dist` is updated: not relevant
- [ ] `playbook.yml.dist` is updated: not relevant
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
