### PR TITLE
Remove AppArmor 'unconfined' profile directive from Vagrantfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations.html.
 
+## Unreleased
+
+### Fixed
+
+- Remove AppArmor 'unconfined' profile directive from Vagrantfile
+
 ## [1.7.0] - 2018-05-19
 
 ### Added

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,8 +118,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         if Vagrant.has_plugin?("vagrant-hostmanager")
             override.hostmanager.ignore_private_ip = true
         end
-        # Cope with AppArmor, as it's enforced on recent Debian
-        lxc.customize 'aa_profile', 'unconfined'
         lxc.backingstore = custom_config.get('backingstore', 'dir')
     end
 


### PR DESCRIPTION
:arrow_up: Ensure you have put a meaningful title in the box up there. :arrow_up:

Setting aa_profile in lxc makes it fail if AppArmor is not installed on the host. Since the profile set here is "unconfined" I assume it's no big deal to totally remove this.

* This PR is a : [Bugfix]

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
