### PR TITLE
Enable assertion exceptions for PHP 7.0 and later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Added
 
 - Added PHP [PhIVE](https://phar.io/) support
+- Added option to enable assert exceptions for PHP 7.0 and above
 - Make ansible version in the guest configurable via parameters.yml
 
 ### Fixed

--- a/docs/roles/php.rst
+++ b/docs/roles/php.rst
@@ -35,6 +35,8 @@ Parameters
 -  **php\_version** : version to install, defaults to 5.6
 -  **php\_error\_reporting** : php error reporting, defaults to "E\_ALL
    \| E\_STRICT"
+-  **php\_assert\_exceptions** : php assert exceptions for 7.0 and above,
+   defaults to false
 -  **php\_max\_execution** \_time\*\* : script max exectution time,
    defaults to "3600"
 -  **php\_memory\_limit** : memory limit, defaults to "4G"

--- a/provisioning/roles/php/defaults/main.yml
+++ b/provisioning/roles/php/defaults/main.yml
@@ -1,6 +1,7 @@
 php_version: "5.6"
 
 php_error_reporting: "E_ALL | E_STRICT"
+php_assert_exceptions: false
 
 php_max_execution_time: "3600"
 php_memory_limit: "4G"

--- a/provisioning/roles/php/templates/php.ini.j2
+++ b/provisioning/roles/php/templates/php.ini.j2
@@ -3,6 +3,10 @@
 display_startup_errors = On
 display_errors = On
 error_reporting = {{ php_error_reporting }}
+{% if php_assert_exceptions %}
+zend.assertions = 1
+assert.exception = 1
+{% endif %}
 
 max_execution_time = {{ php_max_execution_time }}
 memory_limit = {{ php_memory_limit }}


### PR DESCRIPTION
Assertions should be enabled in development mode. Since PHP 7.0 assertions can throw exceptions to make them more visible.

This PR is a: Improvement

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
