### PR TITLE
Make ansible 2.7.0 the default and adapt nginx templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ## Unreleased
 
+### Changed
+
+- Bump ansible default version to 2.7.0
+- Nginx role: update templates "extend" rules to match changes in ansible paths lookup
+
 ### Added
 
 - Added PHP [PhIVE](https://phar.io/) support

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -165,7 +165,7 @@ SCRIPT
             ansible.raw_ssh_args = ['-o ControlMaster=no']
         else
             ansible.install = true
-            ansible.version = custom_config.get('ansible_version', '2.1.1.0')
+            ansible.version = custom_config.get('ansible_version', '2.7.0')
             ansible.install_mode = :pip
         end
     end

--- a/parameters.yml.dist
+++ b/parameters.yml.dist
@@ -86,4 +86,4 @@ root_directory: "/vagrant/"
 
 # Ansible version to use. If you need another version, you can define that here
 # and it will be installed during provisioining.
-# ansible_version: "2.1.1.0"
+# ansible_version: "2.7.0"

--- a/provisioning/roles/nginx/templates/django-site.j2
+++ b/provisioning/roles/nginx/templates/django-site.j2
@@ -1,4 +1,4 @@
-{% extends "nginx/templates/default-site.j2" %}
+{% extends "default-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/drupal6-site.j2
+++ b/provisioning/roles/nginx/templates/drupal6-site.j2
@@ -1,4 +1,4 @@
-{% extends "nginx/templates/php-site.j2" %}
+{% extends "php-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/drupal7-site.j2
+++ b/provisioning/roles/nginx/templates/drupal7-site.j2
@@ -1,4 +1,4 @@
-{% extends "nginx/templates/php-site.j2" %}
+{% extends "php-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/drupal8-site.j2
+++ b/provisioning/roles/nginx/templates/drupal8-site.j2
@@ -1,4 +1,4 @@
-{% extends "nginx/templates/default-site.j2" %}
+{% extends "default-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/php-site.j2
+++ b/provisioning/roles/nginx/templates/php-site.j2
@@ -1,4 +1,4 @@
-{% extends "nginx/templates/default-site.j2" %}
+{% extends "default-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/rails-site.j2
+++ b/provisioning/roles/nginx/templates/rails-site.j2
@@ -1,4 +1,4 @@
-{% extends "nginx/templates/default-site.j2" %}
+{% extends "default-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/silex-site.j2
+++ b/provisioning/roles/nginx/templates/silex-site.j2
@@ -1,4 +1,4 @@
-{% extends "nginx/templates/default-site.j2" %}
+{% extends "default-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/symfony2-site.j2
+++ b/provisioning/roles/nginx/templates/symfony2-site.j2
@@ -1,4 +1,4 @@
-{% extends "nginx/templates/default-site.j2" %}
+{% extends "default-site.j2" %}
 
 {% block extra %}
     {{ super() }}

--- a/provisioning/roles/nginx/templates/symfony4-site.j2
+++ b/provisioning/roles/nginx/templates/symfony4-site.j2
@@ -1,4 +1,4 @@
-{% extends "nginx/templates/default-site.j2" %}
+{% extends "default-site.j2" %}
 
 {% block extra %}
     {{ super() }}


### PR DESCRIPTION
This is a potential fix for #239

- [x] ~Documentation is written~
- [x] `parameters.yml.dist` is updated
- [x] ~`playbook.yml.dist` is updated~
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
