### PR TITLE
Node.js: enable version 9 to 11 and makes 10 the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Changed
 
 - Webpack role: update dependencies, especially upgrade to Babel 7
+- Node.js role: you can now install versions 9.x, 10.x and 11.x; 10.x replaces 8.x as the default
 
 ### Fixed
 

--- a/docs/roles/others.rst
+++ b/docs/roles/others.rst
@@ -19,8 +19,8 @@ Install NodeJS and NPM.
 Parameters
 ----------
 
--  **nodejs\_version** : The version to install, currently supports 8.x,
-   7.x, 6.x, 5.x, 4.x, 0.12 and 0.10, default being 8.x.
+-  **nodejs\_version** : The version to install, currently supports 11.x, 10.x, 9.x, 8.x,
+   7.x, 6.x, 5.x, 4.x, 0.12 and 0.10, default being 10.x.
 -  **nodejs\_distro** : Is automatically set to either 'jessie' or
    'wheezy' based on available information, you can also put an Ubuntu
    codename here.

--- a/provisioning/roles/nodejs/defaults/main.yml
+++ b/provisioning/roles/nodejs/defaults/main.yml
@@ -6,8 +6,8 @@ nodejs_distro: "{{
   'jessie'
 }}"
 nodejs_acceptable_distros: ["wheezy", "jessie", "stretch", "sid", "precise", "trusty"]
-nodejs_version: "8.x"
-nodejs_acceptable_versions: ["8.x", "7.x", "6.x", "5.x", "4.x", "0.12", "0.10"]
+nodejs_version: "10.x"
+nodejs_acceptable_versions: ["11.x", "10.x", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x", "0.12", "0.10"]
 nodejs_with_yarn: false
 nodejs_package_json_template: package.json.j2
 nodejs_package_json_path: "{{ root_directory }}/package.json"


### PR DESCRIPTION
Allow to install Node version 9 to 11 and change the default version from 8 to 10 as it is now the current LTS.

This PR is an Improvement

- [x] Documentation is written
- [x] ~`parameters.yml.dist` is updated~
- [x] ~`playbook.yml.dist` is updated~
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
