### PR TITLE
Node.js role: force installation of the latest npm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Make ansible version in the guest configurable via parameters.yml
 - Django role: download and enable bash completion for django commands
 - Node.js role: allow to disable package.json creation with new parameter `nodejs_create_package_json`
+- Node.js role: force installation of the latest npm version
 
 ### Changed
 

--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -8,14 +8,21 @@
 - name: Make sure APT supports HTTPS sources
   apt: pkg=apt-transport-https state=present
   become: yes
+
 - name: Add nodesource.com apt key
   apt_key: id=68576280 url=https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280 state=present
   become: yes
+
 - name: Add nodesource.com apt repo
   apt_repository: repo='deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ nodejs_distro}} main' state=present update_cache=yes
   become: yes
+
 - name: Install nodejs
   apt: name=nodejs state=present
+  become: yes
+
+- name: Install the latest npm version available
+  npm: name=npm global=yes state=latest
   become: yes
 
 - name: Add Yarn apt key


### PR DESCRIPTION
Developers often complains about weird and/or unexpected changes in their package-lock.json. This is often caused by multiple developers not using the same npm version installed. This PR aims to force the installation of the latest npm version instead of using the one coming by default with the chosen Node version.

* This PR is an Improvement
* Fixes #243 

- [x] ~Documentation is written~
- [x] ~`parameters.yml.dist` is updated~
- [x] ~`playbook.yml.dist` is updated~
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
