### PR TITLE
update ruby-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Changed
 
 - Webpack role: update dependencies, especially upgrade to Babel 7
+- Ruby role: update ruby-build to v20181207
 
 ### Fixed
 

--- a/provisioning/roles/ruby/tasks/main.yml
+++ b/provisioning/roles/ruby/tasks/main.yml
@@ -23,7 +23,7 @@
   git:
     repo: https://github.com/rbenv/ruby-build.git
     dest: ~/.rbenv/plugins/ruby-build
-    version: v20180224
+    version: v20181207
 
 - name: ensure rbenv is accessible
   lineinfile:


### PR DESCRIPTION
update ruby-build to install ruby up to 2.5.3

* This PR is an Improvement

- [ ] ~Documentation is written~
- [ ] ~`parameters.yml.dist` is updated~
- [ ] ~`playbook.yml.dist` is updated~ 
- [ ] ~[Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated~ 
