### PR TITLE
Explicitly set box_name and box_url when creating a new project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 - Webpack role: update dependencies, especially upgrade to Babel 7
 - Ruby role: update ruby-build to v20181207
 - Node.js role: you can now install versions 9.x, 10.x and 11.x; 10.x replaces 8.x as the default
+- Explicitly set box_name and box_url in parameters.yml when creating a new project (fixes #225)
 
 ### Fixed
 

--- a/parameters.yml.dist
+++ b/parameters.yml.dist
@@ -75,8 +75,8 @@ root_directory: "/vagrant/"
 # If you want to use ubuntu instead of debian (or any other box),
 # uncomment this. You can also replace "base" with "php7", if you need
 # php7 (with fpm and nginx) anyway.
-# box_name: "drifter/trusty64-base"
-# box_url: "https://vagrantbox-public.liip.ch/drifter-trusty64-base.json"
+box_name: "drifter/stretch64-base"
+box_url: "https://vagrantbox-public.liip.ch/drifter-stretch64-base.json"
 
 # Default Java version is 7. If you need another java version, uncomment
 # the matching line and set the correct value.


### PR DESCRIPTION
This fixes #225, aka broken setups due to upgrading Drifter to a new version that changed the default box to use. We should also remove the default in the Vagrantfile but doing so will break upgrades from previous versions of Drifter so I'm leaving it here for now.

* This PR is an improvement

- [x] Documentation is written
- [x] `parameters.yml.dist` is updated
- [x] `playbook.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated