### PR TITLE
Make sure apache2 ssl is enabled before creating vhost config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations.html.
 
+## [Unreleased]
+
+### Fixed
+
+- Apache role: fix vhost when SSL is enabled
+
 ## [2.0.2] - 2019-03-21
 
 ### Fixed

--- a/provisioning/roles/apache/tasks/main.yml
+++ b/provisioning/roles/apache/tasks/main.yml
@@ -14,15 +14,6 @@
   when: ansible_lsb.major_release|int >= 8
   notify: reload apache
 
-- name: create vhost config
-  template: src={{ site_template }} dest=/etc/apache2/sites-available/{{ hostname }}.conf
-  become: yes
-
-- name: enable vhost
-  file: src=/etc/apache2/sites-available/{{ hostname }}.conf dest=/etc/apache2/sites-enabled/0001-{{ hostname }}.conf state=link
-  become: yes
-  notify: reload apache
-
 - name: enable apache modules
   apache2_module: state=present name={{ item }}
   become: yes
@@ -39,5 +30,14 @@
   become: yes
   when: ssl
   notify: restart apache
+
+- name: create vhost config
+  template: src={{ site_template }} dest=/etc/apache2/sites-available/{{ hostname }}.conf
+  become: yes
+
+- name: enable vhost
+  file: src=/etc/apache2/sites-available/{{ hostname }}.conf dest=/etc/apache2/sites-enabled/0001-{{ hostname }}.conf state=link
+  become: yes
+  notify: reload apache
 
 - meta: flush_handlers


### PR DESCRIPTION
Since ansible update, apache2 ssl module needs to be enabled before creating the vhost config