### PR TITLE
Add .phpstorm_helpers folder to global git ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 ## [Unreleased]
 
+### Changed
+
+- Global git ignore: add .phpstorm_helpers folder
+
 ### Fixed
 
 - Apache role: fix vhost when SSL is enabled

--- a/provisioning/roles/git/files/gitglobalignore
+++ b/provisioning/roles/git/files/gitglobalignore
@@ -1,6 +1,7 @@
 .vagrant
 
 .idea
+.phpstorm_helpers
 .pycharm_helpers
 phpunit.xml
 atlassian-ide-plugin.xml


### PR DESCRIPTION
That would ease the life of Phpstorm's users since that entry must be set manually for every projects using that specific IDE.

* This PR is a : [Improvement]

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
