### PR TITLE
Nodejs: fix npm install not being triggered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Fixed
 
 - Apache role: fix vhost when SSL is enabled
+- Node.js role: fix "npm install" not being executed
 
 ## [2.0.2] - 2019-03-21
 

--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -41,6 +41,7 @@
 
 - name: Install npm packages
   command: /bin/true
-  notify:
-    - install package.json
+  notify: install package.json
   when: nodejs_install_package_json
+
+- meta: flush_handlers


### PR DESCRIPTION
It worked while being used through another role (webpack for example) but not when you used Nodejs role directly.

- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
