### PR TITLE
use user id based PROJECTS_CACHE_DIR environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For migration information, you can always have a look at https://liip-drifter.re
 
 - Apache role: fix vhost when SSL is enabled
 
+### Added
+
+- Gitlab CI role: PROJECTS_CACHE_DIR_BASE and PROJECTS_CACHE_DIR are provided for using user id based project cache directories.
+
 ## [2.0.2] - 2019-03-21
 
 ### Fixed

--- a/ci/test-header.sh
+++ b/ci/test-header.sh
@@ -4,4 +4,12 @@ finish () {
     exit $1
 }
 
+if [[ -z $PROJECTS_CACHE_DIR_BASE && $(whoami) == 'vagrant' ]]; then
+    PROJECTS_CACHE_DIR_BASE="/home/vagrant/.projects_cache"
+fi
+
+if [[ -z $PROJECTS_CACHE_DIR ]]; then
+    PROJECTS_CACHE_DIR=${PROJECTS_CACHE_DIR_BASE}/$(id -u)
+fi
+
 trap finish EXIT SIGHUP SIGINT SIGTERM

--- a/provisioning/roles/gitlabci/files/run_tests.sh
+++ b/provisioning/roles/gitlabci/files/run_tests.sh
@@ -10,7 +10,7 @@ echo "No tests configured yet! Please adjust $0"
 
 # eg for PHP/composer
 
-## export COMPOSER_CACHE_DIR=~/.projects_cache/composer_cache
+## export COMPOSER_CACHE_DIR=${PROJECTS_CACHE_DIR}/composer_cache
 
 ## echo "- Install dependencies"
 ## composer.phar install --no-interaction;


### PR DESCRIPTION
Docker containers (totally unrelated to drifter somehow, but important on the CI server) sometime have different User id for the running jobs than the drifter default "1000". Therefore generates caches (like composer cache) are not really shareable between those. That's why this patch provides a env variables PROJECTS_CACHE_DIR, which you can use as "ID dependent cache directory", eg. for COMPOSER_CACHE it would be then:

```
COMPOSER_CACHE_DIR=${PROJECTS_CACHE_DIR}/composer_cache
```
only works, if you also include `ci/test-header.sh` in your test script, but the example files do that.

Is backwards compatible. Doesn't change anything if you're still using the old (without user-id) directory style, you may just end up in errors, as you do nowadays.


[Quick description of your PR and motivation.]

* This PR is a : [Bugfix/New feature/Improvement]
* Link to the related issue if relevant

- [ ] Documentation is written
- [ ] `parameters.yml.dist` is updated
- [ ] `playbook.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
