### PR TITLE
Add options for encoding and collation to MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project try to follows [Semantic Versioning](http://semver.org/) since the 
 
 For migration information, you can always have a look at https://liip-drifter.readthedocs.io/en/latest/migrations.html.
 
+## Unreleased
+
+### Changed
+
+- MySQL role: Added options to set encoding and collation
+
 ## [2.0.4] - 2019-07-08
 
 ### Changed

--- a/docs/roles/databases.rst
+++ b/docs/roles/databases.rst
@@ -25,6 +25,8 @@ Parameters
 -  **mysql\_version**: the MySQL version to install, defaults to 5.6 and
    supports 5.6, 5.7 and 8.0 (more info on
    http://dev.mysql.com/downloads/repo/apt/)
+-  **mysql\_character\_set**: the database character set, defaults to "latin1"
+-  **mysql\_collation**: the database collation, defaults to "latin1_swedish_ci"
 
 PostgreSQL
 ==========

--- a/provisioning/roles/mysql/defaults/main.yml
+++ b/provisioning/roles/mysql/defaults/main.yml
@@ -2,3 +2,5 @@ database_user: "{{ database_name }}"
 database_password: "{{ database_name }}"
 mysql_version: 5.7
 mysql_apt_config_version: 0.8.12-1
+mysql_character_set: latin1
+mysql_collation: latin1_swedish_ci

--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -138,4 +138,6 @@
 - name: create database
   mysql_db:
     name: "{{ database_name }}"
+    encoding: "{{ mysql_character_set }}"
+    collation: "{{ mysql_collation }}"
   become: yes


### PR DESCRIPTION
By default, mysql creates a db with `latin1` and `latin1_swedish_ci`. Some apps require different settings.

* This PR is a : New feature

- [x] Documentation is written
- [x] `parameters.yml.dist` is updated
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
