### PR TITLE
Node.js: enable versions 12 and 13 and makes 12 the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For migration information, you can always have a look at https://liip-drifter.re
 ### Changed
 
 - Django role: allow to disable virtualenv usage with `django_use_virtualenv` variable
+- NodeJS role: you can now install versions 13.x and 12.x; 12.x replaces 10.x as the default
 
 ## [2.1.0] - 2019-08-27
 

--- a/docs/roles/others.rst
+++ b/docs/roles/others.rst
@@ -19,8 +19,8 @@ Install NodeJS and NPM.
 Parameters
 ----------
 
--  **nodejs\_version** : The version to install, currently supports 11.x, 10.x, 9.x, 8.x,
-   7.x, 6.x, 5.x, 4.x, 0.12 and 0.10, default being 10.x.
+-  **nodejs\_version** : The version to install, currently supports 13.x, 12.x, 11.x, 10.x, 9.x, 8.x,
+   7.x, 6.x, 5.x, 4.x, 0.12 and 0.10, default being 12.x.
 -  **nodejs\_distro** : Is automatically set to either 'jessie', 'stretch', etc
    based on available information, you can also put an Ubuntu codename here.
 -  **nodejs_create_package_json**: create a ``package.json`` file based on the

--- a/provisioning/roles/nodejs/defaults/main.yml
+++ b/provisioning/roles/nodejs/defaults/main.yml
@@ -6,8 +6,8 @@ nodejs_distro: "{{
   'buster' if (ansible_lsb.major_release|int == 10)
 }}"
 nodejs_acceptable_distros: ["jessie", "stretch", "buster", "sid", "precise", "trusty"]
-nodejs_version: "10.x"
-nodejs_acceptable_versions: ["11.x", "10.x", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x", "0.12", "0.10"]
+nodejs_version: "12.x"
+nodejs_acceptable_versions: ["13.x", "12.x", "11.x", "10.x", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x", "0.12", "0.10"]
 nodejs_with_yarn: false
 nodejs_package_json_template: package.json.j2
 nodejs_package_json_path: "{{ root_directory }}/package.json"


### PR DESCRIPTION
Allow to install Node version 12 to 13 and change the default version from 10 to 12 as it is now the current LTS.

* This PR is an improvement

- [x] Documentation is written
- [x] ~~`parameters.yml.dist` is updated~~
- [x] ~~`playbook.yml.dist` is updated~~
- [x] [Changelog](https://github.com/liip/drifter/blob/master/CHANGELOG.md) was updated
